### PR TITLE
edit db configuration settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,14 +61,43 @@ The full list of configurable options in the `.neotrackerrc` file. These can be 
   "ci": false, // Running as part of continuous integration
   "prod": false, // Compile for production
   "nodeRpcUrl": "http://localhost:9040/rpc", // NEO•ONE Node RPC URL
-  "dbClient": "sqlite3", // Database Client - "sqlite3" or "pg"
-  "dbFileName": "db.sqlite", // Database file - only for SQLite
-  "dbHost": "localhost", // Database host - only for Postgres
-  "dbPort": 5432, // Database port - only for Postgres
-  "dbUser": undefined, // Database username - only for Postgres
-  "dbPassword": undefined, // Database password - only for Postgres
-  "database": "neotracker_prv", // Database name
+  "db": {
+    "client": "sqlite3", // Database Client - "sqlite3" or "pg"
+    "connection": { // Database Connection Configuration (see below for postgres example)
+      "filename": "db.sqlite" // local sqlite database filename
+    }
+  },
   "resetDB": false // Resets database
+}
+```
+
+with a postgres db we have two connection options, a connection string or connection object.
+
+connection string configuration:
+
+```js
+{
+  "db": {
+    "client": "pg",
+    "connection": "postgresql://localhost:5432/neotracker_priv"
+  }
+}
+```
+
+connection object configuration:
+
+```js
+{
+  "db": {
+    "client": "pg",
+    "connection": {
+      "host": "localhost",
+      "port": 5433,
+      "user": "admin" // optional username
+      "password": "password" // optional password
+      "database": "neotracker_priv" // optional database name
+    }
+  }
 }
 ```
 

--- a/packages/neotracker-core/src/NEOTracker.ts
+++ b/packages/neotracker-core/src/NEOTracker.ts
@@ -89,10 +89,10 @@ export class NEOTracker {
       defer(async () => {
         const options = await this.options$.pipe(take(1)).toPromise();
         if (this.environment.start.resetDB) {
-          await dropTables(createFromEnvironment(this.environment.scrape.db, options.scrape.db));
+          await dropTables(createFromEnvironment(options.scrape.db));
         }
 
-        await createTables(createFromEnvironment(this.environment.scrape.db, options.scrape.db));
+        await createTables(createFromEnvironment(options.scrape.db));
       }),
       merge(server$, scrape$),
     ).subscribe({

--- a/packages/neotracker-core/src/options/common.ts
+++ b/packages/neotracker-core/src/options/common.ts
@@ -1,4 +1,4 @@
-import { DBClient } from '@neotracker/server-db';
+import { LiteDBConfig, PGDBConfigString, PGDBConfigWithDatabase } from '../getConfiguration';
 import { Options } from '../NEOTracker';
 
 const userAgents =
@@ -6,33 +6,33 @@ const userAgents =
 const whitelistedUserAgents =
   '(Googlebot|Googlebot-Mobile|Googlebot-Image|Googlebot-News|Googlebot-Video|AdsBot-Google|Mediapartners-Google|Google-Adwords-Instant)';
 
-const db = ({
-  database,
-  filename,
-  client = 'sqlite3',
-  connectionString,
-  user,
-  password,
-}: {
-  readonly database: string;
-  readonly filename: string;
-  readonly client?: DBClient;
-  readonly connectionString?: string;
-  readonly user?: string;
-  readonly password?: string;
-}) => ({
-  // tslint:disable-next-line no-useless-cast
-  client,
-  connection:
-    connectionString !== undefined
-      ? connectionString
-      : {
-          database,
-          user,
-          password,
-          filename,
-        },
-});
+// const db = ({
+//   database,
+//   filename,
+//   client = 'sqlite3',
+//   connectionString,
+//   user,
+//   password,
+// }: {
+//   readonly database: string;
+//   readonly filename: string;
+//   readonly client?: DBClient;
+//   readonly connectionString?: string;
+//   readonly user?: string;
+//   readonly password?: string;
+// }) => ({
+//   // tslint:disable-next-line no-useless-cast
+//   client,
+//   connection:
+//     connectionString !== undefined
+//       ? connectionString
+//       : {
+//           database,
+//           user,
+//           password,
+//           filename,
+//         },
+// });
 
 export interface AssetsConfiguration {
   readonly clientAssetsPath: string;
@@ -47,41 +47,24 @@ export interface AssetsConfiguration {
 
 export const common = ({
   rpcURL,
-  database,
   port,
   blacklistNEP5Hashes,
-  dbFileName,
-  dbUser,
-  dbPassword,
-  dbClient,
-  dbConnectionString,
+  db,
   configuration,
 }: {
   readonly rpcURL: string;
-  readonly database: string;
   readonly port: number;
   readonly blacklistNEP5Hashes: ReadonlyArray<string>;
-  readonly dbFileName: string;
-  readonly dbUser?: string;
-  readonly dbPassword?: string;
-  readonly dbClient?: DBClient;
-  readonly dbConnectionString?: string;
+  readonly db: PGDBConfigWithDatabase | PGDBConfigString | LiteDBConfig;
   readonly configuration: AssetsConfiguration;
 }): Options => ({
   server: {
-    db: db({
-      database,
-      filename: dbFileName,
-      client: dbClient,
-      user: dbUser,
-      password: dbPassword,
-      connectionString: dbConnectionString,
-    }),
+    db,
     rootLoader: {
       cacheEnabled: true,
       cacheSize: 100,
     },
-    subscribeProcessedNextIndex: {},
+    subscribeProcessedNextIndex: { db },
     rateLimit: {
       enabled: true,
       config: {
@@ -178,14 +161,7 @@ export const common = ({
     serveNext: process.env.NEOTRACKER_NEXT === 'true',
   },
   scrape: {
-    db: db({
-      database,
-      filename: dbFileName,
-      client: dbClient,
-      user: dbUser,
-      password: dbPassword,
-      connectionString: dbConnectionString,
-    }),
+    db,
     rootLoader: {
       cacheEnabled: true,
       cacheSize: 100,
@@ -196,14 +172,7 @@ export const common = ({
     repairNEP5BlockFrequency: 10,
     repairNEP5LatencySeconds: 15,
     pubSub: {
-      db: db({
-        database,
-        filename: dbFileName,
-        client: dbClient,
-        user: dbUser,
-        password: dbPassword,
-        connectionString: dbConnectionString,
-      }),
+      db,
     },
   },
 });

--- a/packages/neotracker-core/src/options/index.ts
+++ b/packages/neotracker-core/src/options/index.ts
@@ -4,6 +4,7 @@ import { main } from './main';
 import { priv } from './priv';
 import { test } from './test';
 import { getNetworkOptions } from './utils';
+import { LiteDBConfig, PGDBConfig, PGDBConfigString } from '../getConfiguration';
 
 export { AssetsConfiguration };
 export { main } from './main';
@@ -14,23 +15,13 @@ export { test } from './test';
 export const getOptions = ({
   network,
   port,
-  dbFileName,
-  dbUser,
-  dbPassword,
-  dbClient,
-  dbConnectionString,
-  database,
+  db,
   configuration,
   rpcURL,
 }: {
   readonly network?: string;
   readonly port: number;
-  readonly dbFileName: string;
-  readonly dbUser?: string;
-  readonly dbPassword?: string;
-  readonly dbClient?: DBClient;
-  readonly dbConnectionString?: string;
-  readonly database?: string;
+  readonly db: LiteDBConfig | PGDBConfig | PGDBConfigString;
   readonly configuration: AssetsConfiguration;
   readonly rpcURL?: string;
 }) =>
@@ -38,32 +29,19 @@ export const getOptions = ({
     network,
     main: main({
       port,
-      dbFileName,
-      dbUser,
-      dbPassword,
-      dbClient,
-      dbConnectionString,
+      db,
       configuration,
       rpcURL,
     }),
     test: test({
       port,
-      dbFileName,
-      dbUser,
-      dbPassword,
-      dbClient,
-      dbConnectionString,
+      db,
       configuration,
       rpcURL,
     }),
     priv: priv({
       port,
-      dbFileName,
-      dbUser,
-      dbPassword,
-      dbClient,
-      dbConnectionString,
-      database,
+      db,
       configuration,
       rpcURL,
     }),

--- a/packages/neotracker-core/src/options/main.ts
+++ b/packages/neotracker-core/src/options/main.ts
@@ -1,28 +1,29 @@
-import { DBClient } from '@neotracker/server-db';
+import { isPGDBConfig, LiteDBConfig, PGDBConfig, PGDBConfigString } from '../getConfiguration';
 import { AssetsConfiguration, common } from './common';
 import { mainRPCURL } from './utils';
 
 export const main = ({
   port,
-  dbFileName,
-  dbUser,
-  dbPassword,
-  dbClient,
-  dbConnectionString,
+  db: dbIn,
   configuration,
   rpcURL = mainRPCURL,
 }: {
   readonly port: number;
-  readonly dbFileName: string;
-  readonly dbUser?: string;
-  readonly dbPassword?: string;
-  readonly dbClient?: DBClient;
-  readonly dbConnectionString?: string;
+  readonly db: LiteDBConfig | PGDBConfig | PGDBConfigString;
   readonly configuration: AssetsConfiguration;
   readonly rpcURL?: string;
-}) =>
-  common({
-    database: 'neotracker_main',
+}) => {
+  const db = isPGDBConfig(dbIn)
+    ? {
+        client: dbIn.client,
+        connection: {
+          ...dbIn.connection,
+          database: dbIn.connection.database === undefined ? 'neotracker_priv' : dbIn.connection.database,
+        },
+      }
+    : dbIn;
+
+  return common({
     rpcURL,
     port,
     blacklistNEP5Hashes: [
@@ -36,10 +37,7 @@ export const main = ({
       '2e25d2127e0240c6deaf35394702feb236d4d7fc', //  Narrative Token
       '6d36b38af912ca107f55a5daedc650054f7e4f75',
     ],
-    dbFileName,
-    dbUser,
-    dbPassword,
-    dbClient,
-    dbConnectionString,
+    db,
     configuration,
   });
+};

--- a/packages/neotracker-core/src/options/priv.ts
+++ b/packages/neotracker-core/src/options/priv.ts
@@ -1,37 +1,33 @@
-import { DBClient } from '@neotracker/server-db';
+import { isPGDBConfig, LiteDBConfig, PGDBConfig, PGDBConfigString } from '../getConfiguration';
 import { AssetsConfiguration, common } from './common';
 import { privRPCURL } from './utils';
 
 export const priv = ({
   port,
-  dbFileName,
-  dbUser,
-  dbPassword,
-  dbClient,
-  dbConnectionString,
-  database = 'neotracker_priv',
+  db: dbIn,
   configuration,
   rpcURL = privRPCURL,
 }: {
   readonly port: number;
-  readonly dbFileName: string;
-  readonly dbUser?: string;
-  readonly dbPassword?: string;
-  readonly dbClient?: DBClient;
-  readonly dbConnectionString?: string;
-  readonly database?: string;
+  readonly db: LiteDBConfig | PGDBConfig | PGDBConfigString;
   readonly configuration: AssetsConfiguration;
   readonly rpcURL?: string;
-}) =>
-  common({
-    database,
+}) => {
+  const db = isPGDBConfig(dbIn)
+    ? {
+        client: dbIn.client,
+        connection: {
+          ...dbIn.connection,
+          database: dbIn.connection.database === undefined ? 'neotracker_priv' : dbIn.connection.database,
+        },
+      }
+    : dbIn;
+
+  return common({
+    db,
     rpcURL,
     port,
     blacklistNEP5Hashes: [],
-    dbFileName,
-    dbUser,
-    dbPassword,
-    dbClient,
-    dbConnectionString,
     configuration,
   });
+};

--- a/packages/neotracker-core/src/options/test.ts
+++ b/packages/neotracker-core/src/options/test.ts
@@ -1,35 +1,33 @@
-import { DBClient } from '@neotracker/server-db';
+import { isPGDBConfig, LiteDBConfig, PGDBConfig, PGDBConfigString } from '../getConfiguration';
 import { AssetsConfiguration, common } from './common';
 import { testRPCURL } from './utils';
 
 export const test = ({
   port,
-  dbFileName,
-  dbUser,
-  dbPassword,
-  dbClient,
-  dbConnectionString,
+  db: dbIn,
   configuration,
   rpcURL = testRPCURL,
 }: {
   readonly port: number;
-  readonly dbFileName: string;
-  readonly dbUser?: string;
-  readonly dbPassword?: string;
-  readonly dbClient?: DBClient;
-  readonly dbConnectionString?: string;
+  readonly db: LiteDBConfig | PGDBConfig | PGDBConfigString;
   readonly configuration: AssetsConfiguration;
   readonly rpcURL?: string;
-}) =>
-  common({
-    database: 'neotracker_test',
+}) => {
+  const db = isPGDBConfig(dbIn)
+    ? {
+        client: dbIn.client,
+        connection: {
+          ...dbIn.connection,
+          database: dbIn.connection.database === undefined ? 'neotracker_test' : dbIn.connection.database,
+        },
+      }
+    : dbIn;
+
+  return common({
     rpcURL,
     port,
     blacklistNEP5Hashes: [],
-    dbFileName,
-    dbUser,
-    dbPassword,
-    dbClient,
-    dbConnectionString,
+    db,
     configuration,
   });
+};

--- a/packages/neotracker-server-db/src/channels.ts
+++ b/packages/neotracker-server-db/src/channels.ts
@@ -1,21 +1,18 @@
 import { pubsub as globalPubSub } from '@neotracker/server-utils';
 import { Observable, Observer } from 'rxjs';
 import { share } from 'rxjs/operators';
-import { createPubSub, PROCESSED_NEXT_INDEX, PubSub, PubSubEnvironment, PubSubOptions } from './createPubSub';
+import { createPubSub, PROCESSED_NEXT_INDEX, PubSub, PubSubOptions } from './createPubSub';
 
 // tslint:disable-next-line no-let
 let pubSub: PubSub<{ readonly index: number }> | undefined;
 export const createProcessedNextIndexPubSub = ({
   options,
-  environment,
 }: {
   readonly options: PubSubOptions;
-  readonly environment: PubSubEnvironment;
 }): PubSub<{ readonly index: number }> => {
   if (pubSub === undefined) {
     pubSub = createPubSub<{ readonly index: number }>({
       options,
-      environment,
       channel: PROCESSED_NEXT_INDEX,
     });
   }
@@ -25,13 +22,11 @@ export const createProcessedNextIndexPubSub = ({
 
 export const subscribeProcessedNextIndex = ({
   options,
-  environment,
 }: {
   readonly options: PubSubOptions;
-  readonly environment: PubSubEnvironment;
 }): Observable<{ readonly index: number }> =>
   new Observable((observer: Observer<{ readonly index: number }>) => {
-    const pubsub = createProcessedNextIndexPubSub({ options, environment });
+    const pubsub = createProcessedNextIndexPubSub({ options });
     const subscription = pubsub.value$.subscribe({
       next: (payload) => {
         globalPubSub.publish(PROCESSED_NEXT_INDEX, payload);

--- a/packages/neotracker-server-scrape/src/createScraper$.ts
+++ b/packages/neotracker-server-scrape/src/createScraper$.ts
@@ -15,12 +15,10 @@ import {
   createFromEnvironment$,
   createProcessedNextIndexPubSub,
   createRootLoader$,
-  DBEnvironment,
   DBOptions,
   isHealthyDB,
   NEP5_CONTRACT_TYPE,
   PubSub,
-  PubSubEnvironment,
   PubSubOptions,
   RootLoaderOptions,
 } from '@neotracker/server-db';
@@ -39,9 +37,8 @@ import { WriteCache } from './WriteCache';
 
 export interface Environment {
   readonly network: NetworkType;
-  readonly db: DBEnvironment;
-  readonly pubSub: PubSubEnvironment;
 }
+
 export interface Options {
   readonly db: DBOptions;
   readonly rootLoader: RootLoaderOptions;
@@ -63,7 +60,6 @@ export const createScraper$ = ({
 }): Observable<boolean> => {
   const rootLoader$ = createRootLoader$({
     db$: createFromEnvironment$({
-      environment: environment.db,
       options$: options$.pipe(
         map((options) => options.db),
         distinctUntilChanged(),
@@ -125,7 +121,6 @@ export const createScraper$ = ({
 
       return createProcessedNextIndexPubSub({
         options: pubSubOptions,
-        environment: environment.pubSub,
       });
     }),
   );

--- a/packages/neotracker-server-web/src/createServer$.ts
+++ b/packages/neotracker-server-web/src/createServer$.ts
@@ -1,9 +1,7 @@
 import {
   createFromEnvironment$,
   createRootLoader$,
-  DBEnvironment,
   DBOptions,
-  PubSubEnvironment,
   PubSubOptions,
   RootLoaderOptions,
   subscribeProcessedNextIndex,
@@ -70,8 +68,6 @@ export interface QueryMapEnvironment {
 export interface Environment {
   readonly react: ReactEnvironment;
   readonly reactApp: ReactAppEnvironment;
-  readonly db: DBEnvironment;
-  readonly directDB: PubSubEnvironment;
   readonly server: HTTPServerEnvironment;
   readonly network: NetworkType;
   readonly queryMap?: QueryMapEnvironment;
@@ -128,7 +124,6 @@ export const createServer$ = ({
 
   const rootLoader$ = createRootLoader$({
     db$: createFromEnvironment$({
-      environment: environment.db,
       options$: mapDistinct$((_) => _.options.db),
     }),
 
@@ -171,7 +166,6 @@ export const createServer$ = ({
     switchMap((options) =>
       subscribeProcessedNextIndex({
         options,
-        environment: environment.directDB,
       }),
     ),
   );


### PR DESCRIPTION
title, edit the `db` configuration options so that they are an object as opposed to flattened. Makes it easier to follow the configuration when being passed into other components and also limits any extraneous variables to be passed around (i.e, passing around a default host/port even though I've set a connectionString which overrides those)