### PR TITLE
cleanup configuration options with core/build and fix security deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,14 +61,43 @@ The full list of configurable options in the `.neotrackerrc` file. These can be 
   "ci": false, // Running as part of continuous integration
   "prod": false, // Compile for production
   "nodeRpcUrl": "http://localhost:9040/rpc", // NEO•ONE Node RPC URL
-  "dbClient": "sqlite3", // Database Client - "sqlite3" or "pg"
-  "dbFileName": "db.sqlite", // Database file - only for SQLite
-  "dbHost": "localhost", // Database host - only for Postgres
-  "dbPort": 5432, // Database port - only for Postgres
-  "dbUser": undefined, // Database username - only for Postgres
-  "dbPassword": undefined, // Database password - only for Postgres
-  "database": "neotracker_prv", // Database name
+  "db": {
+    "client": "sqlite3", // Database Client - "sqlite3" or "pg"
+    "connection": { // Database Connection Configuration (see below for postgres example)
+      "filename": "db.sqlite" // local sqlite database filename
+    }
+  },
   "resetDB": false // Resets database
+}
+```
+
+with a postgres db we have two connection options, a connection string or connection object.
+
+connection string configuration:
+
+```js
+{
+  "db": {
+    "client": "pg",
+    "connection": "postgresql://localhost:5432/neotracker_priv"
+  }
+}
+```
+
+connection object configuration:
+
+```js
+{
+  "db": {
+    "client": "pg",
+    "connection": {
+      "host": "localhost",
+      "port": 5433,
+      "user": "admin" // optional username
+      "password": "password" // optional password
+      "database": "neotracker_priv" // optional database name
+    }
+  }
 }
 ```
 

--- a/packages/neotracker-core/src/NEOTracker.ts
+++ b/packages/neotracker-core/src/NEOTracker.ts
@@ -89,10 +89,10 @@ export class NEOTracker {
       defer(async () => {
         const options = await this.options$.pipe(take(1)).toPromise();
         if (this.environment.start.resetDB) {
-          await dropTables(createFromEnvironment(this.environment.scrape.db, options.scrape.db));
+          await dropTables(createFromEnvironment(options.scrape.db));
         }
 
-        await createTables(createFromEnvironment(this.environment.scrape.db, options.scrape.db));
+        await createTables(createFromEnvironment(options.scrape.db));
       }),
       merge(server$, scrape$),
     ).subscribe({

--- a/packages/neotracker-core/src/bin/neotracker.ts
+++ b/packages/neotracker-core/src/bin/neotracker.ts
@@ -1,7 +1,7 @@
 // tslint:disable no-import-side-effect no-let ordered-imports
 import './init';
-import { getConfiguration } from '../getConfiguration';
+import { getCoreConfiguration } from '../getConfiguration';
 import { NEOTracker } from '../NEOTracker';
 
-const neotracker = new NEOTracker(getConfiguration());
+const neotracker = new NEOTracker(getCoreConfiguration());
 neotracker.start();

--- a/packages/neotracker-core/src/getConfiguration.ts
+++ b/packages/neotracker-core/src/getConfiguration.ts
@@ -3,19 +3,62 @@ import rc from 'rc';
 import { BehaviorSubject } from 'rxjs';
 import { getOptions } from './options';
 
+export interface LiteDBConfig {
+  readonly client: 'sqlite3';
+  readonly connection: {
+    readonly filename: string;
+  };
+}
+
+export interface PGDBConfigString {
+  readonly client: 'pg';
+  readonly connection: string;
+}
+
+export interface PGDBConfig {
+  readonly client: 'pg';
+  readonly connection: {
+    readonly host: string;
+    readonly port: number;
+    readonly user?: string;
+    readonly password?: string;
+    readonly database?: string;
+  };
+}
+
+export interface PGDBConfigWithDatabase {
+  readonly client: 'pg';
+  readonly connection: {
+    readonly host: string;
+    readonly port: number;
+    readonly user?: string;
+    readonly password?: string;
+    readonly database: string;
+  };
+}
+
+// tslint:disable-next-line: no-any
+export const isPGDBConfig = (value: { [k in string]: any }): value is PGDBConfig =>
+  value.client === 'pg' &&
+  value.connection !== undefined &&
+  typeof value.connection.host === 'string' &&
+  typeof value.connection.port === 'number';
+
+// tslint:disable-next-line: no-any
+export const isPGDBConfigWithData = (value: { [k in string]: any }): value is PGDBConfigWithDatabase =>
+  isPGDBConfig(value) && value.connection.database !== undefined;
+
+// tslint:disable-next-line: no-any
+export const isLiteDBConfig = (value: { [k in string]: any }): value is LiteDBConfig =>
+  value.client === 'sqlite3' && value.connection !== undefined && typeof value.connection.filename === 'string';
+
 export interface NTConfiguration {
   readonly type: 'all' | 'web' | 'scrape';
   readonly port: number;
   readonly network: 'priv' | 'main' | string;
-  readonly nodeRpcUrl: string;
-  readonly dbClient: 'pg' | 'sqlite3';
-  readonly dbFileName: 'db.sqlite';
-  readonly dbHost: string | undefined;
-  readonly dbPort: number | undefined;
-  readonly dbConnectionString: string | undefined;
-  readonly dbUser: string | undefined;
-  readonly dbPassword: string | undefined;
-  readonly database: string;
+  readonly nodeRpcUrl?: string;
+  readonly metricsPort?: number;
+  readonly db: LiteDBConfig | PGDBConfigString | PGDBConfig;
   readonly resetDB: boolean;
 }
 
@@ -24,106 +67,105 @@ export const defaultNTConfiguration: NTConfiguration = {
   port: process.env.PORT !== undefined ? Number(process.env.PORT) : 1340, // Port to listen on
   network: 'priv', // Network to run against
   nodeRpcUrl: 'http://localhost:9040/rpc', // NEO-ONE Node RPC URL
-  dbHost: 'localhost',
-  dbPort: 5432,
-  dbFileName: 'db.sqlite', // Name of file, if needed
-  dbClient: 'sqlite3',
-  dbConnectionString: process.env.DATABASE_URL, // optional: heroku psql connection
-  dbUser: undefined,
-  dbPassword: undefined,
-  database: 'neotracker_priv',
+  db: {
+    client: 'sqlite3',
+    connection: {
+      filename: 'db.sqlite',
+    },
+  },
   resetDB: false, // Resets database
 };
 
-const {
-  port,
-  network: neotrackerNetwork,
-  nodeRpcUrl: rpcURL,
-  metricsPort,
-  resetDB,
-  dbHost,
-  dbPort,
-  dbFileName,
-  dbConnectionString,
-  dbClient,
-  dbUser,
-  dbPassword,
-  database,
-  type,
-} = rc('neotracker', defaultNTConfiguration);
+export const getConfiguration = (defaultConfig = defaultNTConfiguration): NTConfiguration => {
+  const { port, network, nodeRpcUrl, metricsPort, resetDB, db: dbIn, type } = rc('neotracker', defaultConfig);
 
-// tslint:disable-next-line readonly-array
-const getDistPath = (...paths: string[]) => path.resolve(__dirname, '..', 'dist', ...paths);
-
-const configuration = {
-  clientBundlePath: getDistPath('neotracker-client-web'),
-  clientBundlePathNext: getDistPath('neotracker-client-web-next'),
-  clientPublicPath: '/client/',
-  clientPublicPathNext: '/client-next/',
-  clientAssetsPath: getDistPath('neotracker-client-web', 'assets.json'),
-  clientAssetsPathNext: getDistPath('neotracker-client-web-next', 'assets.json'),
-  statsPath: getDistPath('neotracker-client-web-next', 'stats.json'),
-  rootAssetsPath: getDistPath('root'),
-  publicAssetsPath: getDistPath('public'),
-};
-
-const { options, network } = getOptions({
-  network: neotrackerNetwork,
-  rpcURL,
-  port,
-  dbFileName: path.isAbsolute(dbFileName) ? dbFileName : path.resolve(process.cwd(), dbFileName),
-  dbUser,
-  dbPassword,
-  dbClient,
-  dbConnectionString,
-  database,
-  configuration,
-});
-const options$ = new BehaviorSubject(options);
-
-const db =
-  dbConnectionString !== undefined
+  const db = isLiteDBConfig(dbIn)
     ? {
-        connectionString: dbConnectionString,
+        client: dbIn.client,
+        connection: {
+          filename: path.isAbsolute(dbIn.connection.filename)
+            ? dbIn.connection.filename
+            : path.resolve(process.cwd(), dbIn.connection.filename),
+        },
       }
-    : {
-        host: dbHost,
-        port: dbPort,
-      };
+    : dbIn;
 
-const environment = {
-  server: {
-    react: {
-      appVersion: 'dev',
-    },
-    reactApp: {
-      appVersion: 'dev',
-    },
-    db,
-    directDB: db,
-    server: {
-      host: '0.0.0.0',
-      port,
-    },
+  return {
+    port,
     network,
-    queryMap: {
-      queriesPath: getDistPath('queries.json'),
-      nextQueriesDir: getDistPath('queries'),
-    },
-  },
-  scrape: {
-    db,
-    network,
-    pubSub: {},
-  },
-  start: {
+    nodeRpcUrl,
     metricsPort,
+    db,
+    type,
     resetDB,
-  },
+  };
 };
 
-export const getConfiguration = () => ({
-  environment,
-  options$,
-  type,
-});
+export const getCoreConfiguration = () => {
+  const {
+    port,
+    network: neotrackerNetwork,
+    nodeRpcUrl: rpcURL,
+    metricsPort = 1341,
+    db,
+    type,
+    resetDB,
+  } = getConfiguration();
+  // tslint:disable-next-line readonly-array
+  const getDistPath = (...paths: string[]) => path.resolve(__dirname, '..', 'dist', ...paths);
+
+  const configuration = {
+    clientBundlePath: getDistPath('neotracker-client-web'),
+    clientBundlePathNext: getDistPath('neotracker-client-web-next'),
+    clientPublicPath: '/client/',
+    clientPublicPathNext: '/client-next/',
+    clientAssetsPath: getDistPath('neotracker-client-web', 'assets.json'),
+    clientAssetsPathNext: getDistPath('neotracker-client-web-next', 'assets.json'),
+    statsPath: getDistPath('neotracker-client-web-next', 'stats.json'),
+    rootAssetsPath: getDistPath('root'),
+    publicAssetsPath: getDistPath('public'),
+  };
+
+  const { options, network } = getOptions({
+    network: neotrackerNetwork,
+    rpcURL,
+    port,
+    db,
+    configuration,
+  });
+  const options$ = new BehaviorSubject(options);
+
+  const environment = {
+    server: {
+      react: {
+        appVersion: 'dev',
+      },
+      reactApp: {
+        appVersion: 'dev',
+      },
+      directDB: db,
+      server: {
+        host: '0.0.0.0',
+        port,
+      },
+      network,
+      queryMap: {
+        queriesPath: getDistPath('queries.json'),
+        nextQueriesDir: getDistPath('queries'),
+      },
+    },
+    scrape: {
+      network,
+    },
+    start: {
+      metricsPort,
+      resetDB,
+    },
+  };
+
+  return {
+    environment,
+    options$,
+    type,
+  };
+};

--- a/packages/neotracker-core/src/index.ts
+++ b/packages/neotracker-core/src/index.ts
@@ -1,2 +1,3 @@
 export * from './NEOTracker';
 export * from './options';
+export * from './getConfiguration';

--- a/packages/neotracker-core/src/options/common.ts
+++ b/packages/neotracker-core/src/options/common.ts
@@ -1,4 +1,4 @@
-import { DBClient } from '@neotracker/server-db';
+import { LiteDBConfig, PGDBConfigString, PGDBConfigWithDatabase } from '../getConfiguration';
 import { Options } from '../NEOTracker';
 
 const userAgents =
@@ -6,33 +6,33 @@ const userAgents =
 const whitelistedUserAgents =
   '(Googlebot|Googlebot-Mobile|Googlebot-Image|Googlebot-News|Googlebot-Video|AdsBot-Google|Mediapartners-Google|Google-Adwords-Instant)';
 
-const db = ({
-  database,
-  filename,
-  client = 'sqlite3',
-  connectionString,
-  user,
-  password,
-}: {
-  readonly database: string;
-  readonly filename: string;
-  readonly client?: DBClient;
-  readonly connectionString?: string;
-  readonly user?: string;
-  readonly password?: string;
-}) => ({
-  // tslint:disable-next-line no-useless-cast
-  client,
-  connection:
-    connectionString !== undefined
-      ? connectionString
-      : {
-          database,
-          user,
-          password,
-          filename,
-        },
-});
+// const db = ({
+//   database,
+//   filename,
+//   client = 'sqlite3',
+//   connectionString,
+//   user,
+//   password,
+// }: {
+//   readonly database: string;
+//   readonly filename: string;
+//   readonly client?: DBClient;
+//   readonly connectionString?: string;
+//   readonly user?: string;
+//   readonly password?: string;
+// }) => ({
+//   // tslint:disable-next-line no-useless-cast
+//   client,
+//   connection:
+//     connectionString !== undefined
+//       ? connectionString
+//       : {
+//           database,
+//           user,
+//           password,
+//           filename,
+//         },
+// });
 
 export interface AssetsConfiguration {
   readonly clientAssetsPath: string;
@@ -47,41 +47,24 @@ export interface AssetsConfiguration {
 
 export const common = ({
   rpcURL,
-  database,
   port,
   blacklistNEP5Hashes,
-  dbFileName,
-  dbUser,
-  dbPassword,
-  dbClient,
-  dbConnectionString,
+  db,
   configuration,
 }: {
   readonly rpcURL: string;
-  readonly database: string;
   readonly port: number;
   readonly blacklistNEP5Hashes: ReadonlyArray<string>;
-  readonly dbFileName: string;
-  readonly dbUser?: string;
-  readonly dbPassword?: string;
-  readonly dbClient?: DBClient;
-  readonly dbConnectionString?: string;
+  readonly db: PGDBConfigWithDatabase | PGDBConfigString | LiteDBConfig;
   readonly configuration: AssetsConfiguration;
 }): Options => ({
   server: {
-    db: db({
-      database,
-      filename: dbFileName,
-      client: dbClient,
-      user: dbUser,
-      password: dbPassword,
-      connectionString: dbConnectionString,
-    }),
+    db,
     rootLoader: {
       cacheEnabled: true,
       cacheSize: 100,
     },
-    subscribeProcessedNextIndex: {},
+    subscribeProcessedNextIndex: { db },
     rateLimit: {
       enabled: true,
       config: {
@@ -178,14 +161,7 @@ export const common = ({
     serveNext: process.env.NEOTRACKER_NEXT === 'true',
   },
   scrape: {
-    db: db({
-      database,
-      filename: dbFileName,
-      client: dbClient,
-      user: dbUser,
-      password: dbPassword,
-      connectionString: dbConnectionString,
-    }),
+    db,
     rootLoader: {
       cacheEnabled: true,
       cacheSize: 100,
@@ -196,14 +172,7 @@ export const common = ({
     repairNEP5BlockFrequency: 10,
     repairNEP5LatencySeconds: 15,
     pubSub: {
-      db: db({
-        database,
-        filename: dbFileName,
-        client: dbClient,
-        user: dbUser,
-        password: dbPassword,
-        connectionString: dbConnectionString,
-      }),
+      db,
     },
   },
 });

--- a/packages/neotracker-core/src/options/index.ts
+++ b/packages/neotracker-core/src/options/index.ts
@@ -1,4 +1,4 @@
-import { DBClient } from '@neotracker/server-db';
+import { LiteDBConfig, PGDBConfig, PGDBConfigString } from '../getConfiguration';
 import { AssetsConfiguration } from './common';
 import { main } from './main';
 import { priv } from './priv';
@@ -14,23 +14,13 @@ export { test } from './test';
 export const getOptions = ({
   network,
   port,
-  dbFileName,
-  dbUser,
-  dbPassword,
-  dbClient,
-  dbConnectionString,
-  database,
+  db,
   configuration,
   rpcURL,
 }: {
   readonly network?: string;
   readonly port: number;
-  readonly dbFileName: string;
-  readonly dbUser?: string;
-  readonly dbPassword?: string;
-  readonly dbClient?: DBClient;
-  readonly dbConnectionString?: string;
-  readonly database?: string;
+  readonly db: LiteDBConfig | PGDBConfig | PGDBConfigString;
   readonly configuration: AssetsConfiguration;
   readonly rpcURL?: string;
 }) =>
@@ -38,32 +28,19 @@ export const getOptions = ({
     network,
     main: main({
       port,
-      dbFileName,
-      dbUser,
-      dbPassword,
-      dbClient,
-      dbConnectionString,
+      db,
       configuration,
       rpcURL,
     }),
     test: test({
       port,
-      dbFileName,
-      dbUser,
-      dbPassword,
-      dbClient,
-      dbConnectionString,
+      db,
       configuration,
       rpcURL,
     }),
     priv: priv({
       port,
-      dbFileName,
-      dbUser,
-      dbPassword,
-      dbClient,
-      dbConnectionString,
-      database,
+      db,
       configuration,
       rpcURL,
     }),

--- a/packages/neotracker-core/src/options/main.ts
+++ b/packages/neotracker-core/src/options/main.ts
@@ -1,28 +1,29 @@
-import { DBClient } from '@neotracker/server-db';
+import { isPGDBConfig, LiteDBConfig, PGDBConfig, PGDBConfigString } from '../getConfiguration';
 import { AssetsConfiguration, common } from './common';
 import { mainRPCURL } from './utils';
 
 export const main = ({
   port,
-  dbFileName,
-  dbUser,
-  dbPassword,
-  dbClient,
-  dbConnectionString,
+  db: dbIn,
   configuration,
   rpcURL = mainRPCURL,
 }: {
   readonly port: number;
-  readonly dbFileName: string;
-  readonly dbUser?: string;
-  readonly dbPassword?: string;
-  readonly dbClient?: DBClient;
-  readonly dbConnectionString?: string;
+  readonly db: LiteDBConfig | PGDBConfig | PGDBConfigString;
   readonly configuration: AssetsConfiguration;
   readonly rpcURL?: string;
-}) =>
-  common({
-    database: 'neotracker_main',
+}) => {
+  const db = isPGDBConfig(dbIn)
+    ? {
+        client: dbIn.client,
+        connection: {
+          ...dbIn.connection,
+          database: dbIn.connection.database === undefined ? 'neotracker_priv' : dbIn.connection.database,
+        },
+      }
+    : dbIn;
+
+  return common({
     rpcURL,
     port,
     blacklistNEP5Hashes: [
@@ -36,10 +37,7 @@ export const main = ({
       '2e25d2127e0240c6deaf35394702feb236d4d7fc', //  Narrative Token
       '6d36b38af912ca107f55a5daedc650054f7e4f75',
     ],
-    dbFileName,
-    dbUser,
-    dbPassword,
-    dbClient,
-    dbConnectionString,
+    db,
     configuration,
   });
+};

--- a/packages/neotracker-core/src/options/priv.ts
+++ b/packages/neotracker-core/src/options/priv.ts
@@ -1,37 +1,33 @@
-import { DBClient } from '@neotracker/server-db';
+import { isPGDBConfig, LiteDBConfig, PGDBConfig, PGDBConfigString } from '../getConfiguration';
 import { AssetsConfiguration, common } from './common';
 import { privRPCURL } from './utils';
 
 export const priv = ({
   port,
-  dbFileName,
-  dbUser,
-  dbPassword,
-  dbClient,
-  dbConnectionString,
-  database = 'neotracker_priv',
+  db: dbIn,
   configuration,
   rpcURL = privRPCURL,
 }: {
   readonly port: number;
-  readonly dbFileName: string;
-  readonly dbUser?: string;
-  readonly dbPassword?: string;
-  readonly dbClient?: DBClient;
-  readonly dbConnectionString?: string;
-  readonly database?: string;
+  readonly db: LiteDBConfig | PGDBConfig | PGDBConfigString;
   readonly configuration: AssetsConfiguration;
   readonly rpcURL?: string;
-}) =>
-  common({
-    database,
+}) => {
+  const db = isPGDBConfig(dbIn)
+    ? {
+        client: dbIn.client,
+        connection: {
+          ...dbIn.connection,
+          database: dbIn.connection.database === undefined ? 'neotracker_priv' : dbIn.connection.database,
+        },
+      }
+    : dbIn;
+
+  return common({
+    db,
     rpcURL,
     port,
     blacklistNEP5Hashes: [],
-    dbFileName,
-    dbUser,
-    dbPassword,
-    dbClient,
-    dbConnectionString,
     configuration,
   });
+};

--- a/packages/neotracker-core/src/options/test.ts
+++ b/packages/neotracker-core/src/options/test.ts
@@ -1,35 +1,33 @@
-import { DBClient } from '@neotracker/server-db';
+import { isPGDBConfig, LiteDBConfig, PGDBConfig, PGDBConfigString } from '../getConfiguration';
 import { AssetsConfiguration, common } from './common';
 import { testRPCURL } from './utils';
 
 export const test = ({
   port,
-  dbFileName,
-  dbUser,
-  dbPassword,
-  dbClient,
-  dbConnectionString,
+  db: dbIn,
   configuration,
   rpcURL = testRPCURL,
 }: {
   readonly port: number;
-  readonly dbFileName: string;
-  readonly dbUser?: string;
-  readonly dbPassword?: string;
-  readonly dbClient?: DBClient;
-  readonly dbConnectionString?: string;
+  readonly db: LiteDBConfig | PGDBConfig | PGDBConfigString;
   readonly configuration: AssetsConfiguration;
   readonly rpcURL?: string;
-}) =>
-  common({
-    database: 'neotracker_test',
+}) => {
+  const db = isPGDBConfig(dbIn)
+    ? {
+        client: dbIn.client,
+        connection: {
+          ...dbIn.connection,
+          database: dbIn.connection.database === undefined ? 'neotracker_test' : dbIn.connection.database,
+        },
+      }
+    : dbIn;
+
+  return common({
     rpcURL,
     port,
     blacklistNEP5Hashes: [],
-    dbFileName,
-    dbUser,
-    dbPassword,
-    dbClient,
-    dbConnectionString,
+    db,
     configuration,
   });
+};

--- a/packages/neotracker-server-db/package.json
+++ b/packages/neotracker-server-db/package.json
@@ -21,7 +21,7 @@
     "change-case": "^3.0.2",
     "dataloader": "^1.4.0",
     "graphql": "14.5.8",
-    "knex": "^0.15.2",
+    "knex": "^0.20.8",
     "lodash": "^4.17.11",
     "lru-cache": "^4.1.1",
     "objection": "^1.4.0",

--- a/packages/neotracker-server-db/src/channels.ts
+++ b/packages/neotracker-server-db/src/channels.ts
@@ -1,21 +1,18 @@
 import { pubsub as globalPubSub } from '@neotracker/server-utils';
 import { Observable, Observer } from 'rxjs';
 import { share } from 'rxjs/operators';
-import { createPubSub, PROCESSED_NEXT_INDEX, PubSub, PubSubEnvironment, PubSubOptions } from './createPubSub';
+import { createPubSub, PROCESSED_NEXT_INDEX, PubSub, PubSubOptions } from './createPubSub';
 
 // tslint:disable-next-line no-let
 let pubSub: PubSub<{ readonly index: number }> | undefined;
 export const createProcessedNextIndexPubSub = ({
   options,
-  environment,
 }: {
   readonly options: PubSubOptions;
-  readonly environment: PubSubEnvironment;
 }): PubSub<{ readonly index: number }> => {
   if (pubSub === undefined) {
     pubSub = createPubSub<{ readonly index: number }>({
       options,
-      environment,
       channel: PROCESSED_NEXT_INDEX,
     });
   }
@@ -25,13 +22,11 @@ export const createProcessedNextIndexPubSub = ({
 
 export const subscribeProcessedNextIndex = ({
   options,
-  environment,
 }: {
   readonly options: PubSubOptions;
-  readonly environment: PubSubEnvironment;
 }): Observable<{ readonly index: number }> =>
   new Observable((observer: Observer<{ readonly index: number }>) => {
-    const pubsub = createProcessedNextIndexPubSub({ options, environment });
+    const pubsub = createProcessedNextIndexPubSub({ options });
     const subscription = pubsub.value$.subscribe({
       next: (payload) => {
         globalPubSub.publish(PROCESSED_NEXT_INDEX, payload);

--- a/packages/neotracker-server-scrape-check/package.json
+++ b/packages/neotracker-server-scrape-check/package.json
@@ -13,7 +13,7 @@
     "@neotracker/server-db": "^0.0.1-alpha.0",
     "@neotracker/shared-utils": "^0.0.1-alpha.0",
     "bignumber.js": "^9.0.0",
-    "knex": "^0.15.2",
+    "knex": "^0.20.8",
     "lodash": "^4.17.11"
   },
   "sideEffects": false

--- a/packages/neotracker-server-scrape-check/src/scrapeCheck.ts
+++ b/packages/neotracker-server-scrape-check/src/scrapeCheck.ts
@@ -15,7 +15,6 @@ import {
   Asset as AssetModel,
   Coin as CoinModel,
   createFromEnvironment,
-  DBEnvironment,
   DBOptions,
   makeAllPowerfulQueryContext,
   NEP5_CONTRACT_TYPE,
@@ -28,8 +27,8 @@ import _ from 'lodash';
 
 export interface Environment {
   readonly network: NetworkType;
-  readonly db: DBEnvironment;
 }
+
 export interface Options {
   readonly db: DBOptions;
   readonly rpcURL: string;
@@ -311,7 +310,7 @@ export const scrapeCheck = async ({
     }),
   });
 
-  const db = createFromEnvironment(environment.db, options.db);
+  const db = createFromEnvironment(options.db);
 
   const [blockHeightMismatch, smartContracts] = await Promise.all([
     checkBlockHeightMismatch({

--- a/packages/neotracker-server-scrape/package.json
+++ b/packages/neotracker-server-scrape/package.json
@@ -16,7 +16,7 @@
     "@neotracker/shared-utils": "^0.0.1-alpha.0",
     "bignumber.js": "^9.0.0",
     "ix": "^2.5.3",
-    "knex": "^0.15.2",
+    "knex": "^0.20.8",
     "lodash": "^4.17.11",
     "lru-cache": "^4.1.1",
     "objection": "^1.4.0",

--- a/packages/neotracker-server-scrape/src/createScraper$.ts
+++ b/packages/neotracker-server-scrape/src/createScraper$.ts
@@ -15,12 +15,10 @@ import {
   createFromEnvironment$,
   createProcessedNextIndexPubSub,
   createRootLoader$,
-  DBEnvironment,
   DBOptions,
   isHealthyDB,
   NEP5_CONTRACT_TYPE,
   PubSub,
-  PubSubEnvironment,
   PubSubOptions,
   RootLoaderOptions,
 } from '@neotracker/server-db';
@@ -39,9 +37,8 @@ import { WriteCache } from './WriteCache';
 
 export interface Environment {
   readonly network: NetworkType;
-  readonly db: DBEnvironment;
-  readonly pubSub: PubSubEnvironment;
 }
+
 export interface Options {
   readonly db: DBOptions;
   readonly rootLoader: RootLoaderOptions;
@@ -63,7 +60,6 @@ export const createScraper$ = ({
 }): Observable<boolean> => {
   const rootLoader$ = createRootLoader$({
     db$: createFromEnvironment$({
-      environment: environment.db,
       options$: options$.pipe(
         map((options) => options.db),
         distinctUntilChanged(),
@@ -125,7 +121,6 @@ export const createScraper$ = ({
 
       return createProcessedNextIndexPubSub({
         options: pubSubOptions,
-        environment: environment.pubSub,
       });
     }),
   );

--- a/packages/neotracker-server-test/package.json
+++ b/packages/neotracker-server-test/package.json
@@ -18,7 +18,7 @@
     "fs-extra": "^7.0.1",
     "jest-environment-jsdom": "23.4.0",
     "jest-environment-node": "23.4.0",
-    "knex": "^0.15.2",
+    "knex": "^0.20.8",
     "sqlite3": "4.0.4",
     "tmp": "^0.0.33",
     "uuid": "^3.3.2",

--- a/packages/neotracker-server-web/package.json
+++ b/packages/neotracker-server-web/package.json
@@ -46,7 +46,7 @@
     "react-router-config": "^4.4.0-beta.6",
     "resolve-path": "^1.4.0",
     "rxjs": "^6.3.3",
-    "serialize-javascript": "^1.5.0",
+    "serialize-javascript": "^2.1.2",
     "sitemap": "^5.0.1",
     "styled-components": "^4.1.3",
     "toobusy-js": "^0.5.1"

--- a/packages/neotracker-server-web/src/createServer$.ts
+++ b/packages/neotracker-server-web/src/createServer$.ts
@@ -1,9 +1,7 @@
 import {
   createFromEnvironment$,
   createRootLoader$,
-  DBEnvironment,
   DBOptions,
-  PubSubEnvironment,
   PubSubOptions,
   RootLoaderOptions,
   subscribeProcessedNextIndex,
@@ -70,8 +68,6 @@ export interface QueryMapEnvironment {
 export interface Environment {
   readonly react: ReactEnvironment;
   readonly reactApp: ReactAppEnvironment;
-  readonly db: DBEnvironment;
-  readonly directDB: PubSubEnvironment;
   readonly server: HTTPServerEnvironment;
   readonly network: NetworkType;
   readonly queryMap?: QueryMapEnvironment;
@@ -128,7 +124,6 @@ export const createServer$ = ({
 
   const rootLoader$ = createRootLoader$({
     db$: createFromEnvironment$({
-      environment: environment.db,
       options$: mapDistinct$((_) => _.options.db),
     }),
 
@@ -171,7 +166,6 @@ export const createServer$ = ({
     switchMap((options) =>
       subscribeProcessedNextIndex({
         options,
-        environment: environment.directDB,
       }),
     ),
   );

--- a/yarn.lock
+++ b/yarn.lock
@@ -817,14 +817,7 @@
     core-js "^2.6.5"
     regenerator-runtime "^0.13.2"
 
-"@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2", "@babel/runtime@^7.2.0", "@babel/runtime@^7.4.2", "@babel/runtime@^7.4.5":
-  version "7.6.3"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.6.3.tgz#935122c74c73d2240cafd32ddb5fc2a6cd35cf1f"
-  integrity sha512-kq6anf9JGjW8Nt5rYfEuGRaEAaH1mkv3Bbu6rYvLOpPh/RusSJXuKPEAoZ7L7gybZkchE8+NV5g9vKF4AGAtsA==
-  dependencies:
-    regenerator-runtime "^0.13.2"
-
-"@babel/runtime@^7.6.3":
+"@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2", "@babel/runtime@^7.2.0", "@babel/runtime@^7.4.2", "@babel/runtime@^7.4.5", "@babel/runtime@^7.6.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.8.3.tgz#0811944f73a6c926bb2ad35e918dcc1bfab279f1"
   integrity sha512-fVHx1rzEmwB130VTkLnxR+HmxcTjGzH12LYQcFFoBwakMd3aOMD4OsRN7tGG/UOYE2ektgFrS8uACAoRk1CY0w==
@@ -5948,10 +5941,10 @@ bluebird@3.5.0:
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.0.tgz#791420d7f551eea2897453a8a77653f96606d67c"
   integrity sha1-eRQg1/VR7qKJdFOop3ZT+WYG1nw=
 
-bluebird@^3.5.1, bluebird@^3.5.3, bluebird@^3.5.5:
-  version "3.7.1"
-  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.7.1.tgz#df70e302b471d7473489acf26a93d63b53f874de"
-  integrity sha512-DdmyoGCleJnkbp3nkbxTLJ18rjDsE4yCggEwKNXkeV123sPNfOCYeDoeuOY+F2FrSjO1YXcTU+dsy96KMy+gcg==
+bluebird@^3.5.1, bluebird@^3.5.3, bluebird@^3.5.5, bluebird@^3.7.2:
+  version "3.7.2"
+  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.7.2.tgz#9f229c15be272454ffa973ace0dbee79a1b0c36f"
+  integrity sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==
 
 bn.js@^2.0.0, bn.js@^4.0.0, bn.js@^4.1.0, bn.js@^4.1.1, bn.js@^4.11.8, bn.js@^4.4.0, bn.js@^5.0.0:
   version "4.11.8"
@@ -6150,7 +6143,7 @@ browserslist@4.4.1:
     electron-to-chromium "^1.3.103"
     node-releases "^1.1.3"
 
-browserslist@^4.0.0:
+browserslist@^4.0.0, browserslist@^4.6.0, browserslist@^4.7.2:
   version "4.8.4"
   resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.8.4.tgz#b0cf2470ce928ce86b546217f70825577bb01c3a"
   integrity sha512-3qv/Ar3nRnRTpwGD+LZc7F4YHDBb3NAEIn+DesNa8TcBhyxf8eDqYwTOa70kiWXwvFjQQz+abbykJcyOlfBfNg==
@@ -6158,15 +6151,6 @@ browserslist@^4.0.0:
     caniuse-lite "^1.0.30001021"
     electron-to-chromium "^1.3.338"
     node-releases "^1.1.46"
-
-browserslist@^4.6.0, browserslist@^4.7.2:
-  version "4.7.2"
-  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.7.2.tgz#1bb984531a476b5d389cedecb195b2cd69fb1348"
-  integrity sha512-uZavT/gZXJd2UTi9Ov7/Z340WOSQ3+m1iBVRUknf+okKxonL9P83S3ctiBDtuRmRu8PiCHjqyueqQ9HYlJhxiw==
-  dependencies:
-    caniuse-lite "^1.0.30001004"
-    electron-to-chromium "^1.3.295"
-    node-releases "^1.1.38"
 
 bs-logger@0.x:
   version "0.2.6"
@@ -6460,15 +6444,10 @@ caniuse-api@^3.0.0:
     lodash.memoize "^4.1.2"
     lodash.uniq "^4.5.0"
 
-caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001021:
+caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000929, caniuse-lite@^1.0.30001004, caniuse-lite@^1.0.30001021:
   version "1.0.30001022"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001022.tgz#9eeffe580c3a8f110b7b1742dcf06a395885e4c6"
   integrity sha512-FjwPPtt/I07KyLPkBQ0g7/XuZg6oUkYBVnPHNj3VHJbOjmmJ/GdSo/GUY6MwINEQvjhP6WZVbX8Tvms8xh0D5A==
-
-caniuse-lite@^1.0.30000929, caniuse-lite@^1.0.30001004:
-  version "1.0.30001006"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001006.tgz#5b6e8288792cfa275f007b2819a00ccad7112655"
-  integrity sha512-MXnUVX27aGs/QINz+QG1sWSLDr3P1A3Hq5EUWoIt0T7K24DuvMxZEnh3Y5aHlJW6Bz2aApJdSewdYLd8zQnUuw==
 
 capture-exit@^2.0.0:
   version "2.0.0"
@@ -6499,15 +6478,6 @@ ccount@^1.0.0:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/ccount/-/ccount-1.0.4.tgz#9cf2de494ca84060a2a8d2854edd6dfb0445f386"
   integrity sha512-fpZ81yYfzentuieinmGnphk0pLkOTMm6MZdVqwd77ROvhko6iujLNGrHH5E7utq3ygWklwfmwuG+A7P+NpqT6w==
-
-chalk@2.3.2:
-  version "2.3.2"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.3.2.tgz#250dc96b07491bfd601e648d66ddf5f60c7a5c65"
-  integrity sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==
-  dependencies:
-    ansi-styles "^3.2.1"
-    escape-string-regexp "^1.0.5"
-    supports-color "^5.3.0"
 
 chalk@2.4.2, chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.3.0, chalk@^2.3.1, chalk@^2.3.2, chalk@^2.4.1, chalk@^2.4.2:
   version "2.4.2"
@@ -6674,12 +6644,7 @@ ci-info@^2.0.0:
   resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-2.0.0.tgz#67a9e964be31a51e15e5010d58e6f12834002f46"
   integrity sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==
 
-ci-job-number@^0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/ci-job-number/-/ci-job-number-0.3.0.tgz#34bdd114b0dece1960287bd40a57051041a2a800"
-  integrity sha1-NL3RFLDezhlgKHvUClcFEEGiqAA=
-
-ci-job-number@^0.3.1:
+ci-job-number@^0.3.0, ci-job-number@^0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/ci-job-number/-/ci-job-number-0.3.1.tgz#4354e45bb3ed5a7301f09358d2876d510d4a570e"
   integrity sha512-OfY2Cg+mTqZz7lWOxONGbAXVZNNWPSiyGtOpAjYHEVTXIae8lGCOg3cDfJpPh8zcl+2CqItOsxbvH6ueV+QOmw==
@@ -6957,6 +6922,11 @@ color@^3.0.0:
     color-convert "^1.9.1"
     color-string "^1.5.2"
 
+colorette@1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/colorette/-/colorette-1.1.0.tgz#1f943e5a357fac10b4e0f5aaef3b14cdc1af6ec7"
+  integrity sha512-6S062WDQUXi6hOfkO/sBPVwE5ASXY4G2+b4atvhJfSsuUUhIaUKlkjLe9692Ipyt5/a+IPF5aVTu3V5gvXq5cg==
+
 columnify@^1.5.4:
   version "1.5.4"
   resolved "https://registry.yarnpkg.com/columnify/-/columnify-1.5.4.tgz#4737ddf1c7b69a8a7c340570782e947eec8e78bb"
@@ -6977,10 +6947,15 @@ commander@2.15.1:
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.15.1.tgz#df46e867d0fc2aec66a34662b406a9ccafff5b0f"
   integrity sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==
 
-commander@^2.11.0, commander@^2.12.1, commander@^2.16.0, commander@^2.18.0, commander@^2.19.0, commander@^2.20.0, commander@~2.20.3:
+commander@^2.11.0, commander@^2.12.1, commander@^2.18.0, commander@^2.19.0, commander@^2.20.0, commander@~2.20.3:
   version "2.20.3"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
   integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
+
+commander@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-4.1.0.tgz#545983a0603fe425bc672d66c9e3c89c42121a83"
+  integrity sha512-NIQrwvv9V39FHgGFm36+U9SMQzbiHvU79k+iADraJTpmrFFfx7Ds0IvDoAdZsDrknlkRk14OYoWXb57uTh7/sw==
 
 common-tags@1.8.0, common-tags@^1.5.1:
   version "1.8.0"
@@ -7826,7 +7801,7 @@ debug@3.2.6, debug@^3.1.0, debug@^3.2.5, debug@^3.2.6:
   dependencies:
     ms "^2.1.1"
 
-debug@^4.0.1, debug@^4.1.0, debug@^4.1.1:
+debug@4.1.1, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.1.tgz#3b72260255109c6b589cee050f1d516139664791"
   integrity sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==
@@ -8271,12 +8246,7 @@ ejs@^2.6.1:
   resolved "https://registry.yarnpkg.com/ejs/-/ejs-2.7.1.tgz#5b5ab57f718b79d4aca9254457afecd36fa80228"
   integrity sha512-kS/gEPzZs3Y1rRsbGX4UOSjtP/CeJP0CxSNZHYxGfVM/VgLcv0ZqM7C45YyTj2DI2g7+P9Dd24C+IMIg6D0nYQ==
 
-electron-to-chromium@^1.3.103, electron-to-chromium@^1.3.295:
-  version "1.3.296"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.296.tgz#a1d4322d742317945285d3ba88966561b67f3ac8"
-  integrity sha512-s5hv+TSJSVRsxH190De66YHb50pBGTweT9XGWYu/LMR20KX6TsjFzObo36CjVAzM+PUeeKSBRtm/mISlCzeojQ==
-
-electron-to-chromium@^1.3.338:
+electron-to-chromium@^1.3.103, electron-to-chromium@^1.3.295, electron-to-chromium@^1.3.338:
   version "1.3.338"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.338.tgz#4f33745aed599dfa0fd7b388bf754c164e915168"
   integrity sha512-wlmfixuHEc9CkfOKgcqdtzBmRW4NStM9ptl5oPILY2UDyHuSXb3Yit+yLVyLObTgGuMMU36hhnfs2GDJId7ctA==
@@ -8485,23 +8455,7 @@ error@^7.0.0:
   dependencies:
     string-template "~0.2.1"
 
-es-abstract@^1.12.0, es-abstract@^1.13.0, es-abstract@^1.15.0, es-abstract@^1.5.1, es-abstract@^1.7.0:
-  version "1.16.0"
-  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.16.0.tgz#d3a26dc9c3283ac9750dca569586e976d9dcc06d"
-  integrity sha512-xdQnfykZ9JMEiasTAJZJdMWCQ1Vm00NBw79/AWi7ELfZuuPCSOMDZbT9mkOfSctVtfhb+sAAzrm+j//GjjLHLg==
-  dependencies:
-    es-to-primitive "^1.2.0"
-    function-bind "^1.1.1"
-    has "^1.0.3"
-    has-symbols "^1.0.0"
-    is-callable "^1.1.4"
-    is-regex "^1.0.4"
-    object-inspect "^1.6.0"
-    object-keys "^1.1.1"
-    string.prototype.trimleft "^2.1.0"
-    string.prototype.trimright "^2.1.0"
-
-es-abstract@^1.17.0-next.1, es-abstract@^1.17.2:
+es-abstract@^1.12.0, es-abstract@^1.13.0, es-abstract@^1.15.0, es-abstract@^1.17.0-next.1, es-abstract@^1.17.2, es-abstract@^1.5.1, es-abstract@^1.7.0:
   version "1.17.4"
   resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.17.4.tgz#e3aedf19706b20e7c2594c35fc0d57605a79e184"
   integrity sha512-Ae3um/gb8F0mui/jPL+QiqmglkUsaQf7FwBEHYIFkztkneosu9imhqHpBzQ3h1vit8t5iQ74t6PEVvphBZiuiQ==
@@ -8518,16 +8472,7 @@ es-abstract@^1.17.0-next.1, es-abstract@^1.17.2:
     string.prototype.trimleft "^2.1.1"
     string.prototype.trimright "^2.1.1"
 
-es-to-primitive@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/es-to-primitive/-/es-to-primitive-1.2.0.tgz#edf72478033456e8dda8ef09e00ad9650707f377"
-  integrity sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==
-  dependencies:
-    is-callable "^1.1.4"
-    is-date-object "^1.0.1"
-    is-symbol "^1.0.2"
-
-es-to-primitive@^1.2.1:
+es-to-primitive@^1.2.0, es-to-primitive@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/es-to-primitive/-/es-to-primitive-1.2.1.tgz#e55cd4c9cdc188bcefb03b366c736323fc5c898a"
   integrity sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==
@@ -8774,6 +8719,11 @@ eslint@6.6.0:
     table "^5.2.3"
     text-table "^0.2.0"
     v8-compile-cache "^2.0.3"
+
+esm@^3.2.25:
+  version "3.2.25"
+  resolved "https://registry.yarnpkg.com/esm/-/esm-3.2.25.tgz#342c18c29d56157688ba5ce31f8431fbb795cc10"
+  integrity sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==
 
 espree@^6.1.2:
   version "6.1.2"
@@ -9191,18 +9141,7 @@ fast-glob@^2.0.2, fast-glob@^2.2.2, fast-glob@^2.2.6:
     merge2 "^1.2.3"
     micromatch "^3.1.10"
 
-fast-glob@^3.0.3:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.1.0.tgz#77375a7e3e6f6fc9b18f061cddd28b8d1eec75ae"
-  integrity sha512-TrUz3THiq2Vy3bjfQUB2wNyPdGBeGmdjbzzBLhfHN4YFurYptCKwGq/TfiRavbGywFRzY6U2CdmQ1zmsY5yYaw==
-  dependencies:
-    "@nodelib/fs.stat" "^2.0.2"
-    "@nodelib/fs.walk" "^1.2.3"
-    glob-parent "^5.1.0"
-    merge2 "^1.3.0"
-    micromatch "^4.0.2"
-
-fast-glob@^3.1.1:
+fast-glob@^3.0.3, fast-glob@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.1.1.tgz#87ee30e9e9f3eb40d6f254a7997655da753d7c82"
   integrity sha512-nTCREpBY8w8r+boyFYAx21iL6faSsQynliPHM4Uf56SbkyohCNxpVPEH9xrF5TXKy+IsjkPUHDKiUkzBVRXn9g==
@@ -9437,13 +9376,13 @@ find-up@^4.0.0, find-up@^4.1.0:
     locate-path "^5.0.0"
     path-exists "^4.0.0"
 
-findup-sync@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/findup-sync/-/findup-sync-2.0.0.tgz#9326b1488c22d1a6088650a86901b2d9a90a2cbc"
-  integrity sha1-kyaxSIwi0aYIhlCoaQGy2akKLLw=
+findup-sync@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/findup-sync/-/findup-sync-3.0.0.tgz#17b108f9ee512dfb7a5c7f3c8b27ea9e1a9c08d1"
+  integrity sha512-YbffarhcicEhOrm4CtrwdKBdCuz576RLdhJDsIfvNtxUuhdRet1qZcsMjqbePtAseKdAnDyM/IyXbu7PRPRLYg==
   dependencies:
     detect-file "^1.0.0"
-    is-glob "^3.1.0"
+    is-glob "^4.0.0"
     micromatch "^3.0.4"
     resolve-dir "^1.0.1"
 
@@ -9778,6 +9717,11 @@ get-value@^2.0.3, get-value@^2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/get-value/-/get-value-2.0.6.tgz#dc15ca1c672387ca76bd37ac0a395ba2042a2c28"
   integrity sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=
+
+getopts@2.2.5:
+  version "2.2.5"
+  resolved "https://registry.yarnpkg.com/getopts/-/getopts-2.2.5.tgz#67a0fe471cacb9c687d817cab6450b96dde8313b"
+  integrity sha512-9jb7AW5p3in+IiJWhQiZmmwkpLaR/ccTWdWQCtZM66HJcHHLegowh4q4tSD7gouUyeNvFWRavfK9GXosQHDpFA==
 
 getos@3.1.1:
   version "3.1.1"
@@ -10282,12 +10226,7 @@ has-flag@^4.0.0:
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-4.0.0.tgz#944771fd9c81c81265c4d6941860da06bb59479b"
   integrity sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==
 
-has-symbols@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.0.0.tgz#ba1a8f1af2a0fc39650f5c850367704122063b44"
-  integrity sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=
-
-has-symbols@^1.0.1:
+has-symbols@^1.0.0, has-symbols@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.0.1.tgz#9f5214758a44196c406d9bd76cebf81ec2dd31e8"
   integrity sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==
@@ -10771,15 +10710,7 @@ import-fresh@^2.0.0:
     caller-path "^2.0.0"
     resolve-from "^3.0.0"
 
-import-fresh@^3.0.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/import-fresh/-/import-fresh-3.1.0.tgz#6d33fa1dcef6df930fae003446f33415af905118"
-  integrity sha512-PpuksHKGt8rXfWEr9m9EHIpgyyaltBy8+eF6GJM0QCAxMgxCfucMF3mjecK2QsJr0amJW7gTqh5/wht0z2UhEQ==
-  dependencies:
-    parent-module "^1.0.0"
-    resolve-from "^4.0.0"
-
-import-fresh@^3.1.0:
+import-fresh@^3.0.0, import-fresh@^3.1.0:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/import-fresh/-/import-fresh-3.2.1.tgz#633ff618506e793af5ac91bf48b72677e15cbe66"
   integrity sha512-6e1q1cnWP2RXD9/keSkxHScg508CdXqXWgWBaETNhyuBFz+kUZlKboh+ISK+bU++DmbHimVBrOz/zzPe0sZ3sQ==
@@ -10878,7 +10809,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@2.0.4, inherits@^2.0.1, inherits@^2.0.3, inherits@^2.0.4, inherits@~2.0.1, inherits@~2.0.3:
+inherits@2, inherits@2.0.4, inherits@^2.0.1, inherits@^2.0.3, inherits@^2.0.4, inherits@~2.0.1, inherits@~2.0.3, inherits@~2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
@@ -10969,10 +10900,15 @@ inquirer@^7.0.0:
     strip-ansi "^5.1.0"
     through "^2.3.6"
 
-interpret@^1.0.0, interpret@^1.1.0:
+interpret@^1.0.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.2.0.tgz#d5061a6224be58e8083985f5014d844359576296"
   integrity sha512-mT34yGKMNceBQUoVn7iCDKDntA7SC6gycMAWzGx1z/CMCTV7b2AAtXlo3nRyHZ1FelRkQbQjprHSYGwzLtkVbw==
+
+interpret@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/interpret/-/interpret-2.0.0.tgz#b783ffac0b8371503e9ab39561df223286aa5433"
+  integrity sha512-e0/LknJ8wpMMhTiWcjivB+ESwIuvHnBSlBbmP/pSb8CQJldoj1p2qv7xGZ/+BtbTziYRFSz8OsvdbiX45LtYQA==
 
 invariant@^2.2.2, invariant@^2.2.4:
   version "2.2.4"
@@ -11099,12 +11035,7 @@ is-buffer@^2.0.0:
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-2.0.4.tgz#3e572f23c8411a5cfd9557c849e3665e0b290623"
   integrity sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A==
 
-is-callable@^1.1.4:
-  version "1.1.4"
-  resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.1.4.tgz#1e1adf219e1eeb684d691f9d6a05ff0d30a24d75"
-  integrity sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==
-
-is-callable@^1.1.5:
+is-callable@^1.1.4, is-callable@^1.1.5:
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.1.5.tgz#f7e46b596890456db74e7f6e976cb3273d06faab"
   integrity sha512-ESKv5sMCJB2jnHTWZ3O5itG+O128Hsus4K4Qh1h2/cgn2vbgnLSVqfV46AeJA9D5EeeLa9w81KUXMtn34zhX+Q==
@@ -11403,14 +11334,7 @@ is-redirect@^1.0.0:
   resolved "https://registry.yarnpkg.com/is-redirect/-/is-redirect-1.0.0.tgz#1d03dded53bd8db0f30c26e4f95d36fc7c87dc24"
   integrity sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ=
 
-is-regex@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.0.4.tgz#5517489b547091b0930e095654ced25ee97e9491"
-  integrity sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=
-  dependencies:
-    has "^1.0.1"
-
-is-regex@^1.0.5:
+is-regex@^1.0.4, is-regex@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.0.5.tgz#39d589a358bf18967f726967120b8fc1aed74eae"
   integrity sha512-vlKW17SNq44owv5AQR3Cq0bQPEb8+kF3UKZ2fiZNOWtztYE5i0CzCZxFDwO58qAOWtxdBRVO/V5Qin1wjCqFYQ==
@@ -12438,27 +12362,27 @@ kleur@^3.0.3:
   resolved "https://registry.yarnpkg.com/kleur/-/kleur-3.0.3.tgz#a79c9ecc86ee1ce3fa6206d1216c501f147fc07e"
   integrity sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==
 
-knex@^0.15.2:
-  version "0.15.2"
-  resolved "https://registry.yarnpkg.com/knex/-/knex-0.15.2.tgz#6059b87489605f4cc87599a6d2a9d265709e9340"
-  integrity sha1-YFm4dIlgX0zIdZmm0qnSZXCek0A=
+knex@^0.20.8:
+  version "0.20.8"
+  resolved "https://registry.yarnpkg.com/knex/-/knex-0.20.8.tgz#b41c72773185e1032f4a77074198413521827860"
+  integrity sha512-fLiSg5PIBisORs0M+UGjg2s1P/E1BrYvb/NkSVk6Y90HJujkqLufSC6ag+hDgXqW73mFAF283M6+q3/NW0TrHw==
   dependencies:
-    babel-runtime "^6.26.0"
-    bluebird "^3.5.1"
-    chalk "2.3.2"
-    commander "^2.16.0"
-    debug "3.1.0"
-    inherits "~2.0.3"
-    interpret "^1.1.0"
-    liftoff "2.5.0"
-    lodash "^4.17.10"
-    minimist "1.2.0"
+    bluebird "^3.7.2"
+    colorette "1.1.0"
+    commander "^4.1.0"
+    debug "4.1.1"
+    esm "^3.2.25"
+    getopts "2.2.5"
+    inherits "~2.0.4"
+    interpret "^2.0.0"
+    liftoff "3.1.0"
+    lodash "^4.17.15"
     mkdirp "^0.5.1"
-    pg-connection-string "2.0.0"
-    tarn "^1.1.4"
-    tildify "1.2.0"
-    uuid "^3.3.2"
-    v8flags "^3.1.1"
+    pg-connection-string "2.1.0"
+    tarn "^2.0.0"
+    tildify "2.0.0"
+    uuid "^3.3.3"
+    v8flags "^3.1.3"
 
 known-css-properties@^0.16.0:
   version "0.16.0"
@@ -12757,13 +12681,13 @@ lie@3.1.1:
   dependencies:
     immediate "~3.0.5"
 
-liftoff@2.5.0:
-  version "2.5.0"
-  resolved "https://registry.yarnpkg.com/liftoff/-/liftoff-2.5.0.tgz#2009291bb31cea861bbf10a7c15a28caf75c31ec"
-  integrity sha1-IAkpG7Mc6oYbvxCnwVooyvdcMew=
+liftoff@3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/liftoff/-/liftoff-3.1.0.tgz#c9ba6081f908670607ee79062d700df062c52ed3"
+  integrity sha512-DlIPlJUkCV0Ips2zf2pJP0unEoT1kwYhiiPUGF3s/jtxTCjziNLoiVVh+jqWOWeFi6mmwQ5fNxvAUyPad4Dfog==
   dependencies:
     extend "^3.0.0"
-    findup-sync "^2.0.0"
+    findup-sync "^3.0.0"
     fined "^1.0.1"
     flagged-respawn "^1.0.0"
     is-plain-object "^2.0.4"
@@ -14145,14 +14069,7 @@ node-pre-gyp@^0.12.0:
     semver "^5.3.0"
     tar "^4"
 
-node-releases@^1.1.3, node-releases@^1.1.38:
-  version "1.1.39"
-  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.39.tgz#c1011f30343aff5b633153b10ff691d278d08e8d"
-  integrity sha512-8MRC/ErwNCHOlAFycy9OPca46fQYUjbJRDcZTHVWIGXIjYLM73k70vv3WkYutVnM4cCo4hE0MqBVVZjP6vjISA==
-  dependencies:
-    semver "^6.3.0"
-
-node-releases@^1.1.46:
+node-releases@^1.1.3, node-releases@^1.1.38, node-releases@^1.1.46:
   version "1.1.46"
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.46.tgz#6b262afef1bdc9a950a96df2e77e0d2290f484bf"
   integrity sha512-YOjdx+Uoh9FbRO7yVYbnbt1puRWPQMemR3SutLeyv2XfxKs1ihpe0OLAUwBPEP2ImNH/PZC7SEiC6j32dwRZ7g==
@@ -14344,12 +14261,7 @@ object-copy@^0.1.0:
     define-property "^0.2.5"
     kind-of "^3.0.3"
 
-object-inspect@^1.6.0:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.6.0.tgz#c70b6cbf72f274aab4c34c0c82f5167bf82cf15b"
-  integrity sha512-GJzfBZ6DgDAmnuaM3104jR4s1Myxr3Y3zfIyN4z3UdqN69oSRacNK8UhnobDdC+7J2AHCjGwxQubNJfE70SXXQ==
-
-object-inspect@^1.7.0:
+object-inspect@^1.6.0, object-inspect@^1.7.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.7.0.tgz#f4f6bd181ad77f006b5ece60bd0b6f398ff74a67"
   integrity sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw==
@@ -14411,15 +14323,7 @@ object.fromentries@^2.0.0, object.fromentries@^2.0.1:
     function-bind "^1.1.1"
     has "^1.0.3"
 
-object.getownpropertydescriptors@^2.0.3:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz#8758c846f5b407adab0f236e0986f14b051caa16"
-  integrity sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=
-  dependencies:
-    define-properties "^1.1.2"
-    es-abstract "^1.5.1"
-
-object.getownpropertydescriptors@^2.1.0:
+object.getownpropertydescriptors@^2.0.3, object.getownpropertydescriptors@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.1.0.tgz#369bf1f9592d8ab89d712dced5cb81c7c5352649"
   integrity sha512-Z53Oah9A3TdLoblT7VKJaTDdXdT+lQO+cNpKVnya5JDe9uLvzu1YyY1yFDFrcxrlRgWrEFH0jJtD/IbuwjcEVg==
@@ -15116,10 +15020,10 @@ pg-connection-string@0.1.3:
   resolved "https://registry.yarnpkg.com/pg-connection-string/-/pg-connection-string-0.1.3.tgz#da1847b20940e42ee1492beaf65d49d91b245df7"
   integrity sha1-2hhHsglA5C7hSSvq9l1J2RskXfc=
 
-pg-connection-string@2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/pg-connection-string/-/pg-connection-string-2.0.0.tgz#3eefe5997e06d94821e4d502e42b6a1c73f8df82"
-  integrity sha1-Pu/lmX4G2Ugh5NUC5CtqHHP434I=
+pg-connection-string@2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/pg-connection-string/-/pg-connection-string-2.1.0.tgz#e07258f280476540b24818ebb5dca29e101ca502"
+  integrity sha512-bhlV7Eq09JrRIvo1eKngpwuqKtJnNhZdpdOlvrPrA4dxqXPjxSrbNrfnIDmTpwMyRszrcV4kU5ZA4mMsQUrjdg==
 
 pg-int8@1.0.1:
   version "1.0.1"
@@ -15717,16 +15621,7 @@ postcss@^6.0.1, postcss@^6.0.23:
     source-map "^0.6.1"
     supports-color "^5.4.0"
 
-postcss@^7.0.0, postcss@^7.0.14, postcss@^7.0.19, postcss@^7.0.2, postcss@^7.0.7:
-  version "7.0.21"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-7.0.21.tgz#06bb07824c19c2021c5d056d5b10c35b989f7e17"
-  integrity sha512-uIFtJElxJo29QC753JzhidoAhvp/e/Exezkdhfmt8AymWT6/5B7W1WmponYWkHk2eg6sONyTch0A3nkMPun3SQ==
-  dependencies:
-    chalk "^2.4.2"
-    source-map "^0.6.1"
-    supports-color "^6.1.0"
-
-postcss@^7.0.1, postcss@^7.0.16, postcss@^7.0.23, postcss@^7.0.5, postcss@^7.0.6:
+postcss@^7.0.0, postcss@^7.0.1, postcss@^7.0.14, postcss@^7.0.16, postcss@^7.0.19, postcss@^7.0.2, postcss@^7.0.23, postcss@^7.0.5, postcss@^7.0.6, postcss@^7.0.7:
   version "7.0.26"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-7.0.26.tgz#5ed615cfcab35ba9bbb82414a4fa88ea10429587"
   integrity sha512-IY4oRjpXWYshuTDFxMVkJDtWIk2LhsTlu8bZnbEJA4+bYT16Lvpo8Qv6EvDumhYRgzjZl489pmsY3qVgJQ08nA==
@@ -17277,15 +17172,7 @@ schema-utils@^1.0.0:
     ajv-errors "^1.0.0"
     ajv-keywords "^3.1.0"
 
-schema-utils@^2.1.0:
-  version "2.5.0"
-  resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-2.5.0.tgz#8f254f618d402cc80257486213c8970edfd7c22f"
-  integrity sha512-32ISrwW2scPXHUSusP8qMg5dLUawKkyV+/qIEV9JdXKx+rsM6mi8vZY8khg2M69Qom16rtroWXD3Ybtiws38gQ==
-  dependencies:
-    ajv "^6.10.2"
-    ajv-keywords "^3.4.1"
-
-schema-utils@^2.5.0, schema-utils@^2.6.0, schema-utils@^2.6.4:
+schema-utils@^2.1.0, schema-utils@^2.5.0, schema-utils@^2.6.0, schema-utils@^2.6.4:
   version "2.6.4"
   resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-2.6.4.tgz#a27efbf6e4e78689d91872ee3ccfa57d7bdd0f53"
   integrity sha512-VNjcaUxVnEeun6B2fiiUDjXXBtD4ZSH7pdbfIu1pOFwgptDPLMo/z9jr4sUfsjFVPqDCEin/F7IYlq7/E6yDbQ==
@@ -17367,7 +17254,7 @@ sentence-case@^2.1.0:
     no-case "^2.2.0"
     upper-case-first "^1.1.2"
 
-serialize-javascript@^1.4.0, serialize-javascript@^1.5.0, serialize-javascript@^1.7.0:
+serialize-javascript@^1.4.0, serialize-javascript@^1.7.0:
   version "1.9.1"
   resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-1.9.1.tgz#cfc200aef77b600c47da9bb8149c943e798c2fdb"
   integrity sha512-0Vb/54WJ6k5v8sSWN09S0ora+Hnr+cX40r9F170nT+mSkaxltoE/7R3OrIdBSUv1OoiobH1QoWQbCnAO+e8J1A==
@@ -17958,15 +17845,7 @@ string.prototype.trim@^1.1.2:
     es-abstract "^1.13.0"
     function-bind "^1.1.1"
 
-string.prototype.trimleft@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/string.prototype.trimleft/-/string.prototype.trimleft-2.1.0.tgz#6cc47f0d7eb8d62b0f3701611715a3954591d634"
-  integrity sha512-FJ6b7EgdKxxbDxc79cOlok6Afd++TTs5szo+zJTUyow3ycrRfJVE2pq3vcN53XexvKZu/DJMDfeI/qMiZTrjTw==
-  dependencies:
-    define-properties "^1.1.3"
-    function-bind "^1.1.1"
-
-string.prototype.trimleft@^2.1.1:
+string.prototype.trimleft@^2.1.0, string.prototype.trimleft@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/string.prototype.trimleft/-/string.prototype.trimleft-2.1.1.tgz#9bdb8ac6abd6d602b17a4ed321870d2f8dcefc74"
   integrity sha512-iu2AGd3PuP5Rp7x2kEZCrB2Nf41ehzh+goo8TV7z8/XDBbsvc6HQIlUl9RjkZ4oyrW1XM5UwlGl1oVEaDjg6Ag==
@@ -17974,15 +17853,7 @@ string.prototype.trimleft@^2.1.1:
     define-properties "^1.1.3"
     function-bind "^1.1.1"
 
-string.prototype.trimright@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/string.prototype.trimright/-/string.prototype.trimright-2.1.0.tgz#669d164be9df9b6f7559fa8e89945b168a5a6c58"
-  integrity sha512-fXZTSV55dNBwv16uw+hh5jkghxSnc5oHq+5K/gXgizHwAvMetdAJlHqqoFC1FSDVPYWLkAKl2cxpUT41sV7nSg==
-  dependencies:
-    define-properties "^1.1.3"
-    function-bind "^1.1.1"
-
-string.prototype.trimright@^2.1.1:
+string.prototype.trimright@^2.1.0, string.prototype.trimright@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/string.prototype.trimright/-/string.prototype.trimright-2.1.1.tgz#440314b15996c866ce8a0341894d45186200c5d9"
   integrity sha512-qFvWL3/+QIgZXVmJBfpHmxLB7xsUXz6HsUmP8+5dRaC3Q7oKUv9Vo6aMCRZC1smrtyECFsIT30PqBJ1gTjAs+g==
@@ -18403,10 +18274,10 @@ tar@^4, tar@^4.4.10, tar@^4.4.12, tar@^4.4.8:
     safe-buffer "^5.1.2"
     yallist "^3.0.3"
 
-tarn@^1.1.4:
-  version "1.1.5"
-  resolved "https://registry.yarnpkg.com/tarn/-/tarn-1.1.5.tgz#7be88622e951738b9fa3fb77477309242cdddc2d"
-  integrity sha512-PMtJ3HCLAZeedWjJPgGnCvcphbCOMbtZpjKgLq3qM5Qq9aQud+XHrL0WlrlgnTyS8U+jrjGbEXprFcQrxPy52g==
+tarn@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/tarn/-/tarn-2.0.0.tgz#c68499f69881f99ae955b4317ca7d212d942fdee"
+  integrity sha512-7rNMCZd3s9bhQh47ksAQd92ADFcJUjjbyOvyFjNLwTPpGieFHMC84S+LOzw0fx1uh6hnDz/19r8CPMnIjJlMMA==
 
 tdigest@^0.1.1:
   version "0.1.1"
@@ -18439,22 +18310,7 @@ term-size@^1.2.0:
   dependencies:
     execa "^0.7.0"
 
-terser-webpack-plugin@^1.4.1:
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/terser-webpack-plugin/-/terser-webpack-plugin-1.4.1.tgz#61b18e40eaee5be97e771cdbb10ed1280888c2b4"
-  integrity sha512-ZXmmfiwtCLfz8WKZyYUuuHf3dMYEjg8NrjHMb0JqHVHVOSkzp3cW2/XG1fP3tRhqEqSzMwzzRQGtAPbs4Cncxg==
-  dependencies:
-    cacache "^12.0.2"
-    find-cache-dir "^2.1.0"
-    is-wsl "^1.1.0"
-    schema-utils "^1.0.0"
-    serialize-javascript "^1.7.0"
-    source-map "^0.6.1"
-    terser "^4.1.2"
-    webpack-sources "^1.4.0"
-    worker-farm "^1.7.0"
-
-terser-webpack-plugin@^1.4.3:
+terser-webpack-plugin@^1.4.1, terser-webpack-plugin@^1.4.3:
   version "1.4.3"
   resolved "https://registry.yarnpkg.com/terser-webpack-plugin/-/terser-webpack-plugin-1.4.3.tgz#5ecaf2dbdc5fb99745fd06791f46fc9ddb1c9a7c"
   integrity sha512-QMxecFz/gHQwteWwSo5nTc6UaICqN1bMedC5sMtUc7y3Ha3Q8y6ZO0iCR8pq4RJC8Hjf0FEPEHZqcMB/+DFCrA==
@@ -18570,12 +18426,10 @@ through@2, "through@>=2.2.7 <3", through@^2.3.4, through@^2.3.6, through@^2.3.8:
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
   integrity sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=
 
-tildify@1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/tildify/-/tildify-1.2.0.tgz#dcec03f55dca9b7aa3e5b04f21817eb56e63588a"
-  integrity sha1-3OwD9V3Km3qj5bBPIYF+tW5jWIo=
-  dependencies:
-    os-homedir "^1.0.0"
+tildify@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/tildify/-/tildify-2.0.0.tgz#f205f3674d677ce698b7067a99e949ce03b4754a"
+  integrity sha512-Cc+OraorugtXNfs50hU9KS369rFXCfgGLpfCfvlc+Ud5u6VWmUQsOAa9HbTvheQdYnrdJqqv1e5oIqXppMYnSw==
 
 time-fix-plugin@^2.0.0:
   version "2.0.6"
@@ -19394,7 +19248,7 @@ util-promisify@^2.1.0:
   dependencies:
     object.getownpropertydescriptors "^2.0.3"
 
-util.promisify@1.0.0, util.promisify@^1.0.0:
+util.promisify@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/util.promisify/-/util.promisify-1.0.0.tgz#440f7165a459c9a16dc145eb8e72f35687097030"
   integrity sha512-i+6qA2MPhvoKLuxnJNpXAGhg7HphQOSUq2LKMZD0m15EiskXUkMvKdF4Uui0WYeCUGea+o2cw/ZuwehtfsrNkA==
@@ -19402,7 +19256,7 @@ util.promisify@1.0.0, util.promisify@^1.0.0:
     define-properties "^1.1.2"
     object.getownpropertydescriptors "^2.0.3"
 
-util.promisify@~1.0.0:
+util.promisify@^1.0.0, util.promisify@~1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/util.promisify/-/util.promisify-1.0.1.tgz#6baf7774b80eeb0f7520d8b81d07982a59abbaee"
   integrity sha512-g9JpC/3He3bm38zsLupWryXHoEcS22YHthuPQSJdMy6KNrzIRzWqcsHzD/WUnqe45whVou4VIsPew37DoXWNrA==
@@ -19441,7 +19295,7 @@ v8-compile-cache@^2.0.0, v8-compile-cache@^2.0.3, v8-compile-cache@^2.1.0:
   resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.1.0.tgz#e14de37b31a6d194f5690d67efc4e7f6fc6ab30e"
   integrity sha512-usZBT3PW+LOjM25wbqIlZwPeJV+3OSz3M1k1Ws8snlW39dZyYL9lOGC5FgPVHfk0jKmjiDV8Z0mIbVQPiwFs7g==
 
-v8flags@^3.1.1:
+v8flags@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/v8flags/-/v8flags-3.1.3.tgz#fc9dc23521ca20c5433f81cc4eb9b3033bb105d8"
   integrity sha512-amh9CCg3ZxkzQ48Mhcb8iX7xpAfYJgePHxWMQCBWECpOSqJUXgY26ncA61UTV0BkPqfhcy6mzwCIoP4ygxpW8w==
@@ -19738,36 +19592,7 @@ webpack-sources@^1.0.1, webpack-sources@^1.0.2, webpack-sources@^1.1.0, webpack-
     source-list-map "^2.0.0"
     source-map "~0.6.1"
 
-webpack@^4.28.3:
-  version "4.41.2"
-  resolved "https://registry.yarnpkg.com/webpack/-/webpack-4.41.2.tgz#c34ec76daa3a8468c9b61a50336d8e3303dce74e"
-  integrity sha512-Zhw69edTGfbz9/8JJoyRQ/pq8FYUoY0diOXqW0T6yhgdhCv6wr0hra5DwwWexNRns2Z2+gsnrNcbe9hbGBgk/A==
-  dependencies:
-    "@webassemblyjs/ast" "1.8.5"
-    "@webassemblyjs/helper-module-context" "1.8.5"
-    "@webassemblyjs/wasm-edit" "1.8.5"
-    "@webassemblyjs/wasm-parser" "1.8.5"
-    acorn "^6.2.1"
-    ajv "^6.10.2"
-    ajv-keywords "^3.4.1"
-    chrome-trace-event "^1.0.2"
-    enhanced-resolve "^4.1.0"
-    eslint-scope "^4.0.3"
-    json-parse-better-errors "^1.0.2"
-    loader-runner "^2.4.0"
-    loader-utils "^1.2.3"
-    memory-fs "^0.4.1"
-    micromatch "^3.1.10"
-    mkdirp "^0.5.1"
-    neo-async "^2.6.1"
-    node-libs-browser "^2.2.1"
-    schema-utils "^1.0.0"
-    tapable "^1.1.3"
-    terser-webpack-plugin "^1.4.1"
-    watchpack "^1.6.0"
-    webpack-sources "^1.4.1"
-
-webpack@^4.41.5:
+webpack@^4.28.3, webpack@^4.41.5:
   version "4.41.5"
   resolved "https://registry.yarnpkg.com/webpack/-/webpack-4.41.5.tgz#3210f1886bce5310e62bb97204d18c263341b77c"
   integrity sha512-wp0Co4vpyumnp3KlkmpM5LWuzvZYayDwM2n17EHFr4qxBBbRokC7DJawPJC7TfSFZ9HZ6GsdH40EBj4UV0nmpw==


### PR DESCRIPTION
Moves some code around to allow for a shareable rc configuration function that `@neotracker/core` and `@neotracker/build` can both use. Also updates the configuration template for `db` settings (see README).

Updates `Knex` and `serialize-json` to fix security vulnerabilities.