### PR TITLE
fix logo clipping on loading

### DIFF
--- a/packages/neotracker-shared-web/src/components/common/logo/Logo.js
+++ b/packages/neotracker-shared-web/src/components/common/logo/Logo.js
@@ -90,9 +90,9 @@ function Logo({
   return (
     <svg
       className={className}
-      width={`${width == null ? 24 : width}px`}
+      width={`${width == null ? 28 : width}px`}
       height={`${height == null ? 28 : height}px`}
-      viewBox="0 0 24 28"
+      viewBox="0 0 28 28"
       xmlns="http://www.w3.org/2000/svg"
     >
       {defs}

--- a/packages/neotracker-shared-web/src/components/main/appFooter/AppFooter.js
+++ b/packages/neotracker-shared-web/src/components/main/appFooter/AppFooter.js
@@ -100,7 +100,7 @@ function AppFooter({
       </div>
       <div className={classes.secondRow}>
         <Typography className={classes.copyright} variant="caption">
-          {`${appOptions.meta.name} © 2017`}
+          {`${appOptions.meta.name} © 2020`}
         </Typography>
       </div>
     </div>


### PR DESCRIPTION
logo viewbox was too small on loading, fixed it along with bumping our footer date.