### PR TITLE
fix(CMC API): fix CoinMarketCap API

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,8 @@ The full list of configurable options in the `.neotrackerrc` file. These can be 
       "filename": "db.sqlite" // local sqlite database filename
     }
   },
-  "resetDB": false // Resets database
+  "resetDB": false, // Resets database
+  "coinMarketCapApiKey": "" // API key needed to get current price data from CoinMarketCap. You must supply your own key to make this feature work
 }
 ```
 

--- a/packages/neotracker-build/src/entry/server.ts
+++ b/packages/neotracker-build/src/entry/server.ts
@@ -4,7 +4,16 @@ import { getOptions, NEOTracker, getConfiguration, defaultNTConfiguration } from
 import { BehaviorSubject } from 'rxjs';
 import { configuration } from '../configuration';
 
-const { port, network: neotrackerNetwork, nodeRpcUrl, metricsPort = 1341, db, type, resetDB } = getConfiguration({
+const {
+  port,
+  network: neotrackerNetwork,
+  nodeRpcUrl,
+  metricsPort = 1341,
+  db,
+  type,
+  resetDB,
+  coinMarketCapApiKey,
+} = getConfiguration({
   ...defaultNTConfiguration,
   nodeRpcUrl: undefined,
 });
@@ -49,6 +58,7 @@ const environment = {
       port,
     },
     network,
+    coinMarketCapApiKey,
   },
   scrape: {
     db,

--- a/packages/neotracker-core/src/getConfiguration.ts
+++ b/packages/neotracker-core/src/getConfiguration.ts
@@ -64,6 +64,7 @@ export interface NTConfiguration {
   readonly resetDB: boolean;
   readonly ci: boolean;
   readonly prod: boolean;
+  readonly coinMarketCapApiKey: string;
 }
 
 export const defaultNTConfiguration: NTConfiguration = {
@@ -81,13 +82,23 @@ export const defaultNTConfiguration: NTConfiguration = {
   resetDB: false, // Resets database
   ci: false,
   prod: false,
+  coinMarketCapApiKey: '',
 };
 
 export const getConfiguration = (defaultConfig = defaultNTConfiguration): NTConfiguration => {
-  const { port, network, nodeRpcUrl, metricsPort, resetDB, db: dbIn, type, logLevel, ci, prod } = rc(
-    'neotracker',
-    defaultConfig,
-  );
+  const {
+    port,
+    network,
+    nodeRpcUrl,
+    metricsPort,
+    resetDB,
+    db: dbIn,
+    type,
+    logLevel,
+    ci,
+    prod,
+    coinMarketCapApiKey,
+  } = rc('neotracker', defaultConfig);
 
   setGlobalLogLevel(logLevel);
 
@@ -113,6 +124,7 @@ export const getConfiguration = (defaultConfig = defaultNTConfiguration): NTConf
     resetDB,
     ci,
     prod,
+    coinMarketCapApiKey,
   };
 };
 
@@ -125,6 +137,7 @@ export const getCoreConfiguration = () => {
     db,
     type,
     resetDB,
+    coinMarketCapApiKey,
   } = getConfiguration();
   // tslint:disable-next-line readonly-array
   const getDistPath = (...paths: string[]) => path.resolve(__dirname, '..', 'dist', ...paths);
@@ -168,6 +181,7 @@ export const getCoreConfiguration = () => {
         queriesPath: getDistPath('queries.json'),
         nextQueriesDir: getDistPath('queries'),
       },
+      coinMarketCapApiKey,
     },
     scrape: {
       network,

--- a/packages/neotracker-core/src/options/common.ts
+++ b/packages/neotracker-core/src/options/common.ts
@@ -6,34 +6,6 @@ const userAgents =
 const whitelistedUserAgents =
   '(Googlebot|Googlebot-Mobile|Googlebot-Image|Googlebot-News|Googlebot-Video|AdsBot-Google|Mediapartners-Google|Google-Adwords-Instant)';
 
-// const db = ({
-//   database,
-//   filename,
-//   client = 'sqlite3',
-//   connectionString,
-//   user,
-//   password,
-// }: {
-//   readonly database: string;
-//   readonly filename: string;
-//   readonly client?: DBClient;
-//   readonly connectionString?: string;
-//   readonly user?: string;
-//   readonly password?: string;
-// }) => ({
-//   // tslint:disable-next-line no-useless-cast
-//   client,
-//   connection:
-//     connectionString !== undefined
-//       ? connectionString
-//       : {
-//           database,
-//           user,
-//           password,
-//           filename,
-//         },
-// });
-
 export interface AssetsConfiguration {
   readonly clientAssetsPath: string;
   readonly clientAssetsPathNext: string;

--- a/packages/neotracker-server-graphql/src/lib/RootCall.ts
+++ b/packages/neotracker-server-graphql/src/lib/RootCall.ts
@@ -6,6 +6,7 @@ import { GraphQLResolver } from '../constants';
 export interface RootCallOptions {
   readonly appOptions: AppOptions;
   readonly rootLoader: RootLoader;
+  readonly coinMarketCapApiKey: string;
 }
 
 // tslint:disable-next-line no-unnecessary-class

--- a/packages/neotracker-server-graphql/src/roots/PricesRootCall.ts
+++ b/packages/neotracker-server-graphql/src/roots/PricesRootCall.ts
@@ -109,8 +109,11 @@ export class PricesRootCall extends RootCall {
     // tslint:disable-next-line no-loop-statement
     while (tries >= 0) {
       try {
-        serverGQLLogger.info({ ...logInfo });
         const result = await cryptocompare.histoHour(from, to);
+        serverGQLLogger.info({
+          ...logInfo,
+          cryptoCompareApiCallResult: { data_points_received: result.length, last_data_point: result[0] },
+        });
 
         return result.map((point: any) => ({
           id: `${key}:${point.time}`,
@@ -118,8 +121,8 @@ export class PricesRootCall extends RootCall {
           time: point.time,
           value: point.close,
         }));
-      } catch {
-        serverGQLLogger.error({ ...logInfo });
+      } catch (error) {
+        serverGQLLogger.error({ ...logInfo, error });
         tries -= 1;
       }
     }

--- a/packages/neotracker-server-web/src/createServer$.ts
+++ b/packages/neotracker-server-web/src/createServer$.ts
@@ -71,6 +71,7 @@ export interface Environment {
   readonly server: HTTPServerEnvironment;
   readonly network: NetworkType;
   readonly queryMap?: QueryMapEnvironment;
+  readonly coinMarketCapApiKey: string;
 }
 export interface Options {
   readonly db: DBOptions;
@@ -158,7 +159,11 @@ export const createServer$ = ({
 
   const rootCalls$ = startRootCalls$(
     combineLatest([mapDistinct$((_) => _.options.appOptions), rootLoader$]).pipe(
-      map(([appOptions, rootLoader]) => ({ appOptions, rootLoader })),
+      map(([appOptions, rootLoader]) => ({
+        appOptions,
+        rootLoader,
+        coinMarketCapApiKey: environment.coinMarketCapApiKey,
+      })),
     ),
   );
 

--- a/packages/neotracker-shared-utils/src/index.ts
+++ b/packages/neotracker-shared-utils/src/index.ts
@@ -6,6 +6,7 @@ export * from './labels';
 export * from './neverComplete';
 export * from './numbers';
 export * from './retry';
+export * from './tryParseDateStringToSeconds';
 export * from './tryParseInt';
 export * from './tryParseNumber';
 export * from './ua';

--- a/packages/neotracker-shared-utils/src/tryParseDateStringToSeconds.ts
+++ b/packages/neotracker-shared-utils/src/tryParseDateStringToSeconds.ts
@@ -1,0 +1,24 @@
+import { ClientError, SOMETHING_WENT_WRONG } from './errors';
+
+// tslint:disable-next-line no-null-keyword
+const DEFAULT = Object.create(null);
+
+export const tryParseDateStringToSeconds = ({
+  value,
+  // $FlowFixMe
+  default: defaultValue = DEFAULT,
+}: {
+  readonly value: string;
+  readonly default?: string | undefined | typeof DEFAULT;
+}) => {
+  const result = new Date(value).getTime() / 1000;
+  if (Number.isNaN(result)) {
+    if (defaultValue === DEFAULT) {
+      throw new ClientError(SOMETHING_WENT_WRONG);
+    }
+
+    return defaultValue;
+  }
+
+  return result;
+};


### PR DESCRIPTION
### Description of the Change

CoinMarketCap took their old API offline, which we were using to get current market price and other data for NEO and GAS (GAS is not currently displayed though). CMC requires API users to now signup for their new "pro" API and to use an API key. I signed up and got us an API key we can use for free. Their ping rate limit for the free tier is enough for us to get price data every 5 minutes, instead of the 3 minutes we were previously getting. We think this is fine for now. When we add more price data later we may need/want to upgrade, which will also allow us to hit the endpoint more often.

This also means that anyone running the open-source version of NEO Tracker will need to supply an API key as an environment variable through the RC file, command line, or as a regular NodeJS env variable, if they want that data to show up, which certainly isn't necessary for development. This has been updated in the README.

If the API fails or no key is provided then that data simply won't show up on the front-end and the error will be logged in the console.

### Test Plan

Run NEO Tracker with an API key supplied and see that the current price data displays like normal.

### Issues

#91 