### PR TITLE
fix pubsub stall

### DIFF
--- a/packages/neotracker-server-db/src/createPubSub.ts
+++ b/packages/neotracker-server-db/src/createPubSub.ts
@@ -88,13 +88,21 @@ const createPGPubSub = <T>({
     }
   };
 
+  const attemptClientEnd = (termClient: Client) =>
+    Promise.race([
+      new Promise<void>((resolve) => {
+        setTimeout(resolve, 5000);
+      }),
+      termClient.end(),
+    ]);
+
   const closeClient = async () => {
     const currentClient = client;
     client = createClient();
     connected = false;
     try {
       currentClient.removeAllListeners();
-      await currentClient.end();
+      await attemptClientEnd(currentClient);
     } catch (error) {
       serverDBLogger.error({ title: 'pg_pubsub_close_error', error: error.message });
     }


### PR DESCRIPTION
pubsub was stalling in production when attempting to run `await currentClient.end()`. Locally this would error out and fail allowing the listener to move on and establish a new connection, however when containerized and run through kubernetes this call would stall and never move passed it.

We fix this by adding a race condition to timeout the attempt if it takes too long.

# Possible Drawback
This could possibly lead to an issue where clients aren't closing properly? But seeing as the issue only comes up on the initial run of the listener it should never be a concern.