### PR TITLE
fix(cache): attempt to add back cache except in coin model

### DIFF
--- a/packages/neotracker-core/src/options/common.ts
+++ b/packages/neotracker-core/src/options/common.ts
@@ -33,7 +33,7 @@ export const common = ({
   server: {
     db,
     rootLoader: {
-      cacheEnabled: false,
+      cacheEnabled: true,
       cacheSize: 100,
     },
     subscribeProcessedNextIndex: { db },

--- a/packages/neotracker-server-db/src/loader/createRootLoader$.ts
+++ b/packages/neotracker-server-db/src/loader/createRootLoader$.ts
@@ -17,7 +17,7 @@ export interface Options {
 }
 
 const getLoaderOptions = (options: Options, model: typeof BaseModel) =>
-  options.cacheEnabled && model.cacheType === 'blockchain'
+  options.cacheEnabled && model.cacheType === 'blockchain' && model.modelName !== 'Coin'
     ? {
         cacheMap: makeCache({
           modelClass: model,


### PR DESCRIPTION
### Description of the Change

I really think we shouldn't turn off the cache. But until we figure out the exact problem I think this can turn on the cache for almost all queries, except the ones that aren't working. I think we should try this patch while I dig deeper into what's going on.

### Test Plan

Deploy. See if it takes some query load of the PG DB but still updates wallet balances correctly.
