### PR TITLE
fix(cache): remove caching for coin edges, add analytics tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ The full list of configurable options in the `.neotrackerrc` file. These can be 
   },
   "resetDB": false, // Resets database
   "coinMarketCapApiKey": "" // API key needed to get current price data from CoinMarketCap. You must supply your own key to make this feature work
+  "googleAnalyticsTag": "" // Google Analytics Tag
 }
 ```
 

--- a/packages/neotracker-build/src/entry/server.ts
+++ b/packages/neotracker-build/src/entry/server.ts
@@ -13,6 +13,7 @@ const {
   type,
   resetDB,
   coinMarketCapApiKey,
+  googleAnalyticsTag,
 } = getConfiguration({
   ...defaultNTConfiguration,
   nodeRpcUrl: undefined,
@@ -37,6 +38,7 @@ const { options, network } = getOptions({
   port,
   network: neotrackerNetwork,
   rpcURL,
+  googleAnalyticsTag,
   db,
   configuration,
 });

--- a/packages/neotracker-core/src/getConfiguration.ts
+++ b/packages/neotracker-core/src/getConfiguration.ts
@@ -65,6 +65,7 @@ export interface NTConfiguration {
   readonly ci: boolean;
   readonly prod: boolean;
   readonly coinMarketCapApiKey: string;
+  readonly googleAnalyticsTag: string;
 }
 
 export const defaultNTConfiguration: NTConfiguration = {
@@ -83,6 +84,7 @@ export const defaultNTConfiguration: NTConfiguration = {
   ci: false,
   prod: false,
   coinMarketCapApiKey: '',
+  googleAnalyticsTag: '',
 };
 
 export const getConfiguration = (defaultConfig = defaultNTConfiguration): NTConfiguration => {
@@ -98,6 +100,7 @@ export const getConfiguration = (defaultConfig = defaultNTConfiguration): NTConf
     ci,
     prod,
     coinMarketCapApiKey,
+    googleAnalyticsTag,
   } = rc('neotracker', defaultConfig);
 
   setGlobalLogLevel(logLevel);
@@ -125,6 +128,7 @@ export const getConfiguration = (defaultConfig = defaultNTConfiguration): NTConf
     ci,
     prod,
     coinMarketCapApiKey,
+    googleAnalyticsTag,
   };
 };
 
@@ -138,6 +142,7 @@ export const getCoreConfiguration = () => {
     type,
     resetDB,
     coinMarketCapApiKey,
+    googleAnalyticsTag,
   } = getConfiguration();
   // tslint:disable-next-line readonly-array
   const getDistPath = (...paths: string[]) => path.resolve(__dirname, '..', 'dist', ...paths);
@@ -157,6 +162,7 @@ export const getCoreConfiguration = () => {
   const { options, network } = getOptions({
     network: neotrackerNetwork,
     rpcURL,
+    googleAnalyticsTag,
     port,
     db,
     configuration,

--- a/packages/neotracker-core/src/options/common.ts
+++ b/packages/neotracker-core/src/options/common.ts
@@ -19,12 +19,14 @@ export interface AssetsConfiguration {
 
 export const common = ({
   rpcURL,
+  googleAnalyticsTag,
   port,
   blacklistNEP5Hashes,
   db,
   configuration,
 }: {
   readonly rpcURL: string;
+  readonly googleAnalyticsTag: string;
   readonly port: number;
   readonly blacklistNEP5Hashes: ReadonlyArray<string>;
   readonly db: PGDBConfigWithDatabase | PGDBConfigString | LiteDBConfig;
@@ -51,12 +53,14 @@ export const common = ({
         enabled: true,
         userAgents,
       },
+      googleAnalyticsTag,
       rpcURL,
     },
     reactApp: {
       clientAssetsPath: configuration.clientAssetsPathNext,
       statsPath: configuration.statsPath,
       publicPath: configuration.clientPublicPathNext,
+      googleAnalyticsTag,
       rpcURL,
     },
     toobusy: {

--- a/packages/neotracker-core/src/options/index.ts
+++ b/packages/neotracker-core/src/options/index.ts
@@ -17,12 +17,14 @@ export const getOptions = ({
   db,
   configuration,
   rpcURL,
+  googleAnalyticsTag,
 }: {
   readonly network?: string;
   readonly port: number;
   readonly db: LiteDBConfig | PGDBConfig | PGDBConfigString;
   readonly configuration: AssetsConfiguration;
   readonly rpcURL?: string;
+  readonly googleAnalyticsTag: string;
 }) =>
   getNetworkOptions({
     network,
@@ -31,17 +33,20 @@ export const getOptions = ({
       db,
       configuration,
       rpcURL,
+      googleAnalyticsTag,
     }),
     test: test({
       port,
       db,
       configuration,
       rpcURL,
+      googleAnalyticsTag,
     }),
     priv: priv({
       port,
       db,
       configuration,
       rpcURL,
+      googleAnalyticsTag,
     }),
   });

--- a/packages/neotracker-core/src/options/main.ts
+++ b/packages/neotracker-core/src/options/main.ts
@@ -7,11 +7,13 @@ export const main = ({
   db: dbIn,
   configuration,
   rpcURL = mainRPCURL,
+  googleAnalyticsTag,
 }: {
   readonly port: number;
   readonly db: LiteDBConfig | PGDBConfig | PGDBConfigString;
   readonly configuration: AssetsConfiguration;
   readonly rpcURL?: string;
+  readonly googleAnalyticsTag: string;
 }) => {
   const db = isPGDBConfig(dbIn)
     ? {
@@ -25,6 +27,7 @@ export const main = ({
 
   return common({
     rpcURL,
+    googleAnalyticsTag,
     port,
     blacklistNEP5Hashes: [
       '4b4f63919b9ecfd2483f0c72ff46ed31b5bbb7a4', //  Phantasma

--- a/packages/neotracker-core/src/options/priv.ts
+++ b/packages/neotracker-core/src/options/priv.ts
@@ -7,11 +7,13 @@ export const priv = ({
   db: dbIn,
   configuration,
   rpcURL = privRPCURL,
+  googleAnalyticsTag,
 }: {
   readonly port: number;
   readonly db: LiteDBConfig | PGDBConfig | PGDBConfigString;
   readonly configuration: AssetsConfiguration;
   readonly rpcURL?: string;
+  readonly googleAnalyticsTag: string;
 }) => {
   const db = isPGDBConfig(dbIn)
     ? {
@@ -26,6 +28,7 @@ export const priv = ({
   return common({
     db,
     rpcURL,
+    googleAnalyticsTag,
     port,
     blacklistNEP5Hashes: [],
     configuration,

--- a/packages/neotracker-core/src/options/test.ts
+++ b/packages/neotracker-core/src/options/test.ts
@@ -7,11 +7,13 @@ export const test = ({
   db: dbIn,
   configuration,
   rpcURL = testRPCURL,
+  googleAnalyticsTag,
 }: {
   readonly port: number;
   readonly db: LiteDBConfig | PGDBConfig | PGDBConfigString;
   readonly configuration: AssetsConfiguration;
   readonly rpcURL?: string;
+  readonly googleAnalyticsTag: string;
 }) => {
   const db = isPGDBConfig(dbIn)
     ? {
@@ -25,6 +27,7 @@ export const test = ({
 
   return common({
     rpcURL,
+    googleAnalyticsTag,
     port,
     blacklistNEP5Hashes: [],
     db,

--- a/packages/neotracker-server-db/src/loader/createRootLoader$.ts
+++ b/packages/neotracker-server-db/src/loader/createRootLoader$.ts
@@ -17,7 +17,7 @@ export interface Options {
 }
 
 const getLoaderOptions = (options: Options, model: typeof BaseModel) =>
-  options.cacheEnabled && model.cacheType === 'blockchain' && model.modelName !== 'Coin'
+  options.cacheEnabled && model.cacheType === 'blockchain'
     ? {
         cacheMap: makeCache({
           modelClass: model,

--- a/packages/neotracker-server-graphql/src/gen/ResolverBuilder.ts
+++ b/packages/neotracker-server-graphql/src/gen/ResolverBuilder.ts
@@ -358,8 +358,18 @@ export class ResolverBuilder {
         if (field == undefined) {
           return undefined;
         }
+        // Clear the cache for that address when we check coin balances so we get latest balance from DB
+        if (edge.name === 'coins') {
+          obj.getLoaderByEdge(context.rootLoader.makeQueryContext(), edge.name).clear({ id: field });
+        }
 
-        return obj.getLoaderByEdge(context.rootLoader.makeQueryContext(), edge.name).load({ id: field });
+        const result = await obj.getLoaderByEdge(context.rootLoader.makeQueryContext(), edge.name).load({ id: field });
+
+        if (edge.name === 'coins') {
+          obj.getLoaderByEdge(context.rootLoader.makeQueryContext(), edge.name).clear({ id: field });
+        }
+
+        return result;
       }
 
       const builder = obj
@@ -403,9 +413,18 @@ export class ResolverBuilder {
         if (field == undefined) {
           return {};
         }
+
+        // Clear the cache for that address when we check coin balances so we get latest balance from DB
+        if (edge.name === 'coins') {
+          obj.getLoaderByEdge(context.rootLoader.makeQueryContext(), edge.name).clear({ id: field });
+        }
         const results: any[] = await obj
           .getLoaderByEdge(context.rootLoader.makeQueryContext(), edge.name)
           .load({ id: field });
+
+        if (edge.name === 'coins') {
+          obj.getLoaderByEdge(context.rootLoader.makeQueryContext(), edge.name).clear({ id: field });
+        }
 
         return {
           edges: results.map((result, idx) => ({

--- a/packages/neotracker-server-web/src/middleware/reactApp/index.tsx
+++ b/packages/neotracker-server-web/src/middleware/reactApp/index.tsx
@@ -133,6 +133,7 @@ export interface Options {
   readonly statsPath: string;
   readonly publicPath: string;
   readonly rpcURL: string;
+  readonly googleAnalyticsTag: string;
   readonly adsenseID?: string;
   readonly bsaEnabled?: boolean;
 }
@@ -200,6 +201,7 @@ export const reactApp = ({
           js: bundlePaths,
           reactAppString,
           nonce,
+          googleAnalyticsTag: options.googleAnalyticsTag,
           helmet: reactHelmet,
           apolloState,
           styles,

--- a/packages/neotracker-server-web/src/middleware/reactApp/makeServerHTML.tsx
+++ b/packages/neotracker-server-web/src/middleware/reactApp/makeServerHTML.tsx
@@ -28,6 +28,7 @@ interface Props {
   readonly js: ReadonlyArray<string>;
   readonly helmet: HelmetData;
   readonly nonce: string;
+  readonly googleAnalyticsTag: string;
   readonly reactAppString: string;
   readonly apolloState: NormalizedCacheObject;
   readonly styles: ReadonlyArray<React.ReactElement<{}>>;
@@ -46,6 +47,7 @@ export const makeServerHTML = ({
   js,
   helmet,
   nonce,
+  googleAnalyticsTag,
   reactAppString,
   apolloState,
   styles,
@@ -110,6 +112,18 @@ export const makeServerHTML = ({
     `,
           'adsense',
         ),
+    googleAnalyticsTag === ''
+      ? undefined
+      : scriptTag(`https://www.googletagmanager.com/gtag/js?id=${googleAnalyticsTag}`, { async: true }),
+    googleAnalyticsTag === ''
+      ? undefined
+      : inlineScript(`
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config','${googleAnalyticsTag}');
+    `),
   ]
     .filter(utils.notNull)
     .concat(styles);

--- a/packages/neotracker-server-web/src/middleware/reactApplication/index.tsx
+++ b/packages/neotracker-server-web/src/middleware/reactApplication/index.tsx
@@ -195,6 +195,7 @@ export interface Options {
     readonly userAgents: string;
   };
   readonly rpcURL: string;
+  readonly googleAnalyticsTag: string;
   readonly adsenseID?: string;
   readonly bsaEnabled?: boolean;
 }
@@ -259,6 +260,7 @@ export const reactApplication = ({
           js: [asset.js],
           reactAppString,
           nonce,
+          googleAnalyticsTag: options.googleAnalyticsTag,
           helmet: reactHelmet,
           relay,
           records,

--- a/packages/neotracker-server-web/src/middleware/reactApplication/makeServerHTML.tsx
+++ b/packages/neotracker-server-web/src/middleware/reactApplication/makeServerHTML.tsx
@@ -17,6 +17,7 @@ interface Props {
   readonly js: ReadonlyArray<string>;
   readonly helmet: HelmetData;
   readonly nonce: string;
+  readonly googleAnalyticsTag: string;
   readonly reactAppString: string;
   // tslint:disable-next-line no-any
   readonly relay?: () => any;
@@ -38,6 +39,7 @@ export const makeServerHTML = ({
   js,
   helmet,
   nonce,
+  googleAnalyticsTag,
   reactAppString,
   relay,
   records,
@@ -96,6 +98,18 @@ export const makeServerHTML = ({
         google_ad_client: "${adsenseID}",
         enable_page_level_ads: true
       });
+    `),
+    googleAnalyticsTag === ''
+      ? undefined
+      : scriptTag(`https://www.googletagmanager.com/gtag/js?id=${googleAnalyticsTag}`, { async: true }),
+    googleAnalyticsTag === ''
+      ? undefined
+      : inlineScript(`
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config','${googleAnalyticsTag}');
     `),
   ].filter(utils.notNull);
 


### PR DESCRIPTION
### Description of the Change

Adds the ability to add a Google Analytics Tag to NEO Tracker. Just set `googleAnalyticsTag` in the RC file.

Adds back more caching and removes caching just for coin "edges" so that we still take advantage of the cache everywhere except for coin edges.

### Test Plan

I tested the Google Analytics Tag locally. It registers the analytics in Google Analytics when passed a tag through the RC file.

I tested the GAS claiming and NEO transfers locally. They work. The same behavior should be observed for other coins, but that should be tested in staging.

### Issues

#120 
#112 
