### PR TITLE
fix(logger): make logging cleaner, more controllable

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ The full list of configurable options in the `.neotrackerrc` file. These can be 
 
 ```js
 {
-  "type": "all", Components to run: "all" | "scrape" | "web"
+  "type": "all", // Components to run: "all" | "scrape" | "web"
   "port": 1340, // Port the website will be on
   "network": "priv", // NEO network to run on
   "ci": false, // Running as part of continuous integration
@@ -68,6 +68,7 @@ The full list of configurable options in the `.neotrackerrc` file. These can be 
     }
   },
   "resetDB": false, // Resets database
+  "logLevel": "info", // Sets pino log level globally: "trace" | "debug" | "info" | "warn" | "error" | "fatal" | "silent"
   "coinMarketCapApiKey": "" // API key needed to get current price data from CoinMarketCap. You must supply your own key to make this feature work
 }
 ```

--- a/packages/neotracker-build/src/HotCompilerServer.ts
+++ b/packages/neotracker-build/src/HotCompilerServer.ts
@@ -1,3 +1,4 @@
+import { topLevelLogger } from '@neotracker/logger';
 import * as appRootDir from 'app-root-dir';
 import { ChildProcess } from 'child_process';
 import execa from 'execa';
@@ -109,13 +110,9 @@ export class HotCompilerServer implements HotServer {
       message: 'Server running with latest changes.',
     });
     if (newServer.stdout !== null) {
-      newServer.stdout.on('data', (data) =>
-        log({
-          title: this.title,
-          level: 'info',
-          message: data.toString().trim(),
-        }),
-      );
+      newServer.stdout.on('data', (data) => {
+        topLevelLogger.info(data.toString().trim());
+      });
     }
     if (newServer.stderr !== null) {
       newServer.stderr.on('data', (data) => {

--- a/packages/neotracker-build/src/develop.ts
+++ b/packages/neotracker-build/src/develop.ts
@@ -1,3 +1,4 @@
+import { setGlobalLogLevel } from '@neotracker/logger';
 import rc from 'rc';
 import { HotWebServer } from './HotWebServer';
 
@@ -5,6 +6,10 @@ const ntConfig = rc('neotracker', {
   ci: false, // Running as part of continuous integration
   prod: false, // Compile for production
 });
+
+if (ntConfig.logLevel !== undefined) {
+  setGlobalLogLevel(ntConfig.logLevel);
+}
 
 const server = new HotWebServer({
   isCI: ntConfig.ci,

--- a/packages/neotracker-logger/src/loggers.ts
+++ b/packages/neotracker-logger/src/loggers.ts
@@ -10,18 +10,33 @@ const createLogger = (service: string, options: pino.LoggerOptions = {}) =>
         process.env.NODE_ENV === 'production' ? pino.extreme(1) : pino.destination(1),
       );
 
+const defaultOptions = { timestamp: false };
 const browserOptions =
   // tslint:disable-next-line: strict-type-predicates
-  typeof window === 'undefined' && typeof origin === 'undefined' ? {} : { browser: { asObject: true } };
+  typeof window === 'undefined' && typeof origin === 'undefined'
+    ? { ...defaultOptions }
+    : { ...defaultOptions, browser: { asObject: true } };
 
 export const clientLogger = createLogger('client', browserOptions);
 export const coreLogger = createLogger('core', browserOptions);
 export const serverLogger = createLogger('server', browserOptions);
 export const webLogger = createLogger('web', browserOptions);
 export const utilsLogger = createLogger('utils', browserOptions);
+export const topLevelLogger = pino({
+  // tslint:disable-next-line: no-null-keyword
+  base: null,
+  prettyPrint: { colorize: true, translateTime: 'SYS:mm-dd-yy hh:MM:ssTT' },
+});
 
 // tslint:disable-next-line: no-let
-let loggers: ReadonlyArray<pino.Logger> = [clientLogger, coreLogger, serverLogger, webLogger, utilsLogger];
+let loggers: ReadonlyArray<pino.Logger> = [
+  clientLogger,
+  coreLogger,
+  serverLogger,
+  webLogger,
+  utilsLogger,
+  topLevelLogger,
+];
 export const setGlobalLogLevel = (level: pino.LevelWithSilent) =>
   loggers.forEach((logger) => {
     // tslint:disable-next-line no-object-mutation


### PR DESCRIPTION
### Description of the Change

Logging was out of control. Trying to use `setGlobalLogLevel` didn't work with `yarn develop` because of how `stdout` was handled in `HotCompilerServer.ts`. I replaced `log()` with a new `topLevelLogger`. This is not a *great* solution, but it's much better. You can set `logLevel` on the command line or in the RC file and `yarn develop` will actually see that through.

This does change the format and colors a bit:

Build logs are the same:
<img width="1262" alt="Screen Shot 2020-03-26 at 5 48 53 PM" src="https://user-images.githubusercontent.com/29364457/77710015-211dea00-6f8a-11ea-886e-365316197b66.png">

But all other logs now have better timestamp formats and slightly better color contrasts:
<img width="1261" alt="Screen Shot 2020-03-26 at 5 49 03 PM" src="https://user-images.githubusercontent.com/29364457/77710019-224f1700-6f8a-11ea-8482-dd1640a3ac54.png">

### Test Plan

Try `yarn develop --logLevel silent`. You'll only get the build logs and nothing else.

### Issues

#124 
