### PR TITLE
fix(gas): fix gas claiming bug

### DIFF
--- a/packages/neotracker-server-db/src/utils/calculateAddressClaimValue.ts
+++ b/packages/neotracker-server-db/src/utils/calculateAddressClaimValue.ts
@@ -11,6 +11,7 @@ export const calculateAddressClaimValue = async (
   context: GraphQLContext,
   _info: GraphQLResolveInfo,
 ): Promise<string> => {
+  context.rootLoader.maxIndexFetcher.reset();
   const [unclaimed, currentHeight] = await Promise.all([
     TransactionInputOutput.query(context.rootLoader.db)
       .context(context.rootLoader.makeQueryContext())


### PR DESCRIPTION
### Description of the Change

The GAS available to claim is calculated in `neotracker-server-db/src/utils/calculateAddressClaimValue.ts`. This function goes several levels deeper and even uses a `@neo-one/utils` function `calculateClaimAmount`. But part of the input to that was the current block height, which would become out of sync with the actual current block height, causing the problem with the calculated GAS claim value. It appears that when you did claim GAS that the current `maxIndex` block wouldn't change, even though the correct claim transaction was sent to the blockchain. This would cause the apparent discrepancy between the amount that was claimable and the amount that was actually claimed on the blockchain.

To fix this we just reset the `maxIndexFetcher` loader right before we get the max block height for calculating available GAS, so the max block height is always the latest available value, and thus we get the correct claimable GAS value every time it's calculated.

### Test Plan

`yarn develop`

Look at the GAS claim balance. You should see the balance go up every block as you get claimable GAS. Then claim GAS. You should see your balance go up by the amount available and then simultaneously the claimable balance will go to zero when the claim is confirmed.

### Issues

#113 
