### PR TITLE
Logging changes to mute browser logs

### DIFF
--- a/packages/neotracker-build/src/HotCompilerServer.ts
+++ b/packages/neotracker-build/src/HotCompilerServer.ts
@@ -1,4 +1,3 @@
-import { topLevelLogger } from '@neotracker/logger';
 import * as appRootDir from 'app-root-dir';
 import { ChildProcess } from 'child_process';
 import execa from 'execa';
@@ -111,7 +110,7 @@ export class HotCompilerServer implements HotServer {
     });
     if (newServer.stdout !== null) {
       newServer.stdout.on('data', (data) => {
-        topLevelLogger.info(data.toString().trim());
+        process.stdout.write(data);
       });
     }
     if (newServer.stderr !== null) {

--- a/packages/neotracker-build/src/log.ts
+++ b/packages/neotracker-build/src/log.ts
@@ -1,5 +1,4 @@
-import chalk from 'chalk';
-import logger from 'fancy-log';
+import { topLevelLogger } from '@neotracker/logger';
 
 export function log({
   title,
@@ -10,17 +9,15 @@ export function log({
   readonly level?: 'info' | 'warn' | 'error';
   readonly message: string;
 }): void {
-  const msg = `==> ${title} -> ${message}`;
-
   switch (level) {
     case 'warn':
-      logger(chalk.yellow(msg));
+      topLevelLogger.warn({ title, message });
       break;
     case 'error':
-      logger(chalk.bgRed.white(msg));
+      topLevelLogger.error({ title, message });
       break;
     case 'info':
     default:
-      logger(chalk.green(msg));
+      topLevelLogger.info({ title, message });
   }
 }

--- a/packages/neotracker-logger/package.json
+++ b/packages/neotracker-logger/package.json
@@ -9,8 +9,7 @@
   "main": "./src/index.ts",
   "dependencies": {
     "@types/pino": "^5.8.10",
-    "pino": "^5.13.2",
-    "pino-pretty": "^3.2.1"
+    "pino": "^5.13.2"
   },
   "sideEffects": false
 }

--- a/packages/neotracker-logger/src/index.ts
+++ b/packages/neotracker-logger/src/index.ts
@@ -1,3 +1,2 @@
 export * from './loggers';
-export * from './pretty';
 export * from './types';

--- a/packages/neotracker-logger/src/loggers.ts
+++ b/packages/neotracker-logger/src/loggers.ts
@@ -1,32 +1,30 @@
 // tslint:disable: match-default-export-name
 import pino from 'pino';
-import { getPretty } from './pretty';
 
 const createLogger = (service: string, options: pino.LoggerOptions = {}) =>
   options.browser !== undefined
-    ? pino({ ...options, base: { service }, prettyPrint: getPretty() })
+    ? pino({ ...options, base: { service } })
     : pino(
-        { ...options, base: { service }, prettyPrint: getPretty() },
+        { ...options, base: { service } },
         process.env.NODE_ENV === 'production' ? pino.extreme(1) : pino.destination(1),
       );
 
-const defaultOptions = { timestamp: false };
 const browserOptions =
   // tslint:disable-next-line: strict-type-predicates
-  typeof window === 'undefined' && typeof origin === 'undefined'
-    ? { ...defaultOptions }
-    : { ...defaultOptions, browser: { asObject: true } };
+  typeof window === 'undefined' && typeof origin === 'undefined' ? {} : { browser: { asObject: true } };
 
-export const clientLogger = createLogger('client', browserOptions);
 export const coreLogger = createLogger('core', browserOptions);
 export const serverLogger = createLogger('server', browserOptions);
-export const webLogger = createLogger('web', browserOptions);
 export const utilsLogger = createLogger('utils', browserOptions);
-export const topLevelLogger = pino({
-  // tslint:disable-next-line: no-null-keyword
-  base: null,
-  prettyPrint: { colorize: true, translateTime: 'SYS:mm-dd-yy hh:MM:ssTT' },
-});
+export const topLevelLogger = createLogger('compiler', browserOptions);
+
+/*
+  hacky way to get the web console logs hidden besides errors
+  the client/web doesn't seem to inherit the logLevels we set in a .neotrackerrc
+  I suspect there is somewhere in the client code we should call setLogLevel
+*/
+export const clientLogger = createLogger('client', { level: 'error', ...browserOptions });
+export const webLogger = createLogger('web', { level: 'error', ...browserOptions });
 
 // tslint:disable-next-line: no-let
 let loggers: ReadonlyArray<pino.Logger> = [

--- a/packages/neotracker-logger/src/pretty.ts
+++ b/packages/neotracker-logger/src/pretty.ts
@@ -1,6 +1,0 @@
-// tslint:disable-next-line no-let
-let pretty = false;
-export const getPretty = () => pretty;
-export const setPretty = (newPretty: boolean) => {
-  pretty = newPretty;
-};


### PR DESCRIPTION
### Description
1. Ditch fancy-log (there is probably an argument here that we could use this for just the compiler logging in `yarn develop` and `yarn build-core`)
2. Set client/web logger default level to 'error'
3. the server will always pickup the logging level we have set and apply it but we need to implement the same functionality for the browser. (not sure where this should be set, somewhere in `@neo-one/client-web` probably)

### Revisit
we should revisit either the fancy-log library for compiler logging, or revisit the pino-pretty default. I was initially opposed to using pino-pretty directly in our code, but having to pipe it in even for a command like `yarn build-core` seems unnecessary. 

Here is example output from `yarn build-core` *without* pino-pretty being piped in:
```
{"level":30,"time":1585344497292,"service":"compiler","title":"build","message":"Creating a bundle configuration for the client","v":1}
{"level":30,"time":1585344497585,"service":"compiler","title":"build","message":"Creating a bundle configuration for the client-next","v":1}
{"level":30,"time":1585344497628,"service":"compiler","title":"build","message":"Creating a bundle configuration for the server","v":1}
{"level":30,"time":1585344497645,"service":"compiler","title":"client","message":"Building new bundle...","v":1}
10% building 0/0 modules 0 active{"level":30,"time":1585344497666,"service":"compiler","title":"client-next","message":"Building new bundle...","v":1}
10% building 0/0 modules 0 active{"level":30,"time":1585344497670,"service":"compiler","title":"server","message":"Building new bundle...","v":1}
{"level":30,"time":1585344520153,"service":"compiler","title":"server","message":"Compilation complete.","v":1}
{"level":30,"time":1585344555156,"service":"compiler","title":"client-next","message":"Compilation complete.","v":1}
{"level":30,"time":1585344589552,"service":"compiler","title":"client","message":"Compilation complete.","v":1}
{"level":30,"time":1585344589680,"service":"compiler","title":"build","message":"build successful.","v":1}
✨  Done in 95.35s.
```