### PR TITLE
fix(url): remove port from url if using main url

### DIFF
--- a/packages/neotracker-core/src/options/common.ts
+++ b/packages/neotracker-core/src/options/common.ts
@@ -1,5 +1,6 @@
 import { LiteDBConfig, PGDBConfigString, PGDBConfigWithDatabase } from '../getConfiguration';
 import { Options } from '../NEOTracker';
+import { neotrackerURL } from './utils';
 
 const userAgents =
   '(Alexabot|Googlebot|Googlebot-Mobile|Googlebot-Image|Googlebot-News|Googlebot-Video|AdsBot-Google|Mediapartners-Google|bingbot|slurp|java|wget|curl|Commons-HttpClient|Python-urllib|libwww|httpunit|nutch|Go-http-client|phpcrawl|msnbot|jyxobot|FAST-WebCrawler|FAST Enterprise Crawler|biglotron|teoma|convera|seekbot|gigabot|gigablast|exabot|ngbot|ia_archiver|GingerCrawler|webmon |httrack|webcrawler|grub.org|UsineNouvelleCrawler|antibot|netresearchserver|speedy|fluffy|bibnum.bnf|findlink|msrbot|panscient|yacybot|AISearchBot|IOI|ips-agent|tagoobot|MJ12bot|woriobot|yanga|buzzbot|mlbot|yandexbot|yandex.com\\/bots|purebot|Linguee Bot|CyberPatrol|voilabot|baiduspider|citeseerxbot|spbot|twengabot|postrank|turnitinbot|scribdbot|page2rss|sitebot|linkdex|Adidxbot|blekkobot|ezooms|dotbot|Mail.RU_Bot|discobot|heritrix|findthatfile|europarchive.org|NerdByNature.Bot|sistrix crawler|ahrefsbot|Aboundex|domaincrawler|wbsearchbot|summify|ccbot|edisterbot|seznambot|ec2linkfinder|gslfbot|aihitbot|intelium_bot|facebookexternalhit|yeti|RetrevoPageAnalyzer|lb-spider|sogou|lssbot|careerbot|wotbox|wocbot|ichiro|DuckDuckBot|lssrocketcrawler|drupact|webcompanycrawler|acoonbot|openindexspider|gnam gnam spider|web-archive-net.com.bot|backlinkcrawler|coccoc|integromedb|content crawler spider|toplistbot|seokicks-robot|it2media-domain-crawler|ip-web-crawler.com|siteexplorer.info|elisabot|proximic|changedetection|blexbot|arabot|WeSEE:Search|niki-bot|CrystalSemanticsBot|rogerbot|360Spider|psbot|InterfaxScanBot|CC Metadata Scaper|g00g1e.net|GrapeshotCrawler|urlappendbot|brainobot|fr-crawler|binlar|SimpleCrawler|Twitterbot|cXensebot|smtbot|bnf.fr_bot|A6-Indexer|ADmantX|Facebot|OrangeBot|memorybot|AdvBot|MegaIndex|SemanticScholarBot|ltx71|nerdybot|xovibot|BUbiNG|Qwantify|archive.org_bot|Applebot|TweetmemeBot|crawler4j|findxbot|SemrushBot|yoozBot|lipperhey|y!j-asr|Domain Re-Animator Bot|AddThis|Screaming Frog SEO Spider|MetaURI|Scrapy|LivelapBot|OpenHoseBot|CapsuleChecker|collection@infegy.com|IstellaBot|DeuSu\\/|betaBot|Cliqzbot\\/|MojeekBot\\/|netEstate NE Crawler|SafeSearch microdata crawler|Gluten Free Crawler\\/|Sonic|Sysomos|Trove|deadlinkchecker|Slack-ImgProxy|Embedly|RankActiveLinkBot|iskanie|SafeDNSBot|SkypeUriPreview|Veoozbot|Slackbot|redditbot|datagnionbot|Google-Adwords-Instant|adbeat_bot|Scanbot|WhatsApp|contxbot|pinterest|electricmonk|GarlikCrawler|BingPreview\\/|vebidoobot|FemtosearchBot|Yahoo Link Preview)';
@@ -131,7 +132,7 @@ export const common = ({
         },
         donateAddress: 'AKDVzYGLczmykdtRaejgvWeZrvdkVEvQ1X',
       },
-      url: `${url}:${port}`,
+      url: url === neotrackerURL ? url : `${url}:${port}`,
       rpcURL,
       maintenance: false,
       disableWalletModify: false,

--- a/packages/neotracker-core/src/options/main.ts
+++ b/packages/neotracker-core/src/options/main.ts
@@ -1,6 +1,6 @@
 import { isPGDBConfig, LiteDBConfig, PGDBConfig, PGDBConfigString } from '../getConfiguration';
 import { AssetsConfiguration, common } from './common';
-import { mainRPCURL } from './utils';
+import { mainRPCURL, neotrackerDomain, neotrackerURL } from './utils';
 
 export const main = ({
   port,
@@ -8,8 +8,8 @@ export const main = ({
   configuration,
   rpcURL = mainRPCURL,
   googleAnalyticsTag,
-  url = 'https://neotracker.io',
-  domain = 'neotracker.io',
+  url = neotrackerURL,
+  domain = neotrackerDomain,
 }: {
   readonly port: number;
   readonly db: LiteDBConfig | PGDBConfig | PGDBConfigString;

--- a/packages/neotracker-core/src/options/utils.ts
+++ b/packages/neotracker-core/src/options/utils.ts
@@ -3,6 +3,8 @@ import { NetworkType } from '@neotracker/shared-utils';
 export const mainRPCURL = 'https://neotracker.io/rpc';
 export const testRPCURL = 'https://testnet.neotracker.io/rpc';
 export const privRPCURL = 'http://localhost:9040/rpc';
+export const neotrackerURL = 'https://neotracker.io';
+export const neotrackerDomain = 'neotracker.io';
 
 export function getNetworkOptions<T>({
   network = 'priv',


### PR DESCRIPTION
### Description of the Change

The `url` was incorrect in `main` because it was appending the `port` to the URL, which should only be done for `localhost`.
