### PR TITLE
fix(https): enable HTTPS redirect middleware in prod mode

### DIFF
--- a/packages/neotracker-build/src/entry/server.ts
+++ b/packages/neotracker-build/src/entry/server.ts
@@ -14,6 +14,7 @@ const {
   resetDB,
   coinMarketCapApiKey,
   googleAnalyticsTag,
+  prod,
 } = getConfiguration({
   ...defaultNTConfiguration,
   nodeRpcUrl: undefined,
@@ -41,6 +42,7 @@ const { options, network } = getOptions({
   googleAnalyticsTag,
   db,
   configuration,
+  prod,
 });
 
 const options$ = new BehaviorSubject(options);

--- a/packages/neotracker-core/src/getConfiguration.ts
+++ b/packages/neotracker-core/src/getConfiguration.ts
@@ -143,6 +143,7 @@ export const getCoreConfiguration = () => {
     resetDB,
     coinMarketCapApiKey,
     googleAnalyticsTag,
+    prod,
   } = getConfiguration();
   // tslint:disable-next-line readonly-array
   const getDistPath = (...paths: string[]) => path.resolve(__dirname, '..', 'dist', ...paths);
@@ -166,6 +167,7 @@ export const getCoreConfiguration = () => {
     port,
     db,
     configuration,
+    prod,
   });
   const options$ = new BehaviorSubject(options);
 

--- a/packages/neotracker-core/src/options/common.ts
+++ b/packages/neotracker-core/src/options/common.ts
@@ -26,6 +26,7 @@ export const common = ({
   configuration,
   url = `http://127.0.0.1`,
   domain = '127.0.0.1',
+  prod,
 }: {
   readonly rpcURL: string;
   readonly googleAnalyticsTag: string;
@@ -35,6 +36,7 @@ export const common = ({
   readonly configuration: AssetsConfiguration;
   readonly url?: string;
   readonly domain?: string;
+  readonly prod: boolean;
 }): Options => ({
   server: {
     db,
@@ -75,7 +77,7 @@ export const common = ({
       smoothingFactor: 1 / 3,
     },
     security: {
-      enforceHTTPs: false,
+      enforceHTTPs: prod,
       frameguard: {
         enabled: true,
         action: 'deny',

--- a/packages/neotracker-core/src/options/index.ts
+++ b/packages/neotracker-core/src/options/index.ts
@@ -18,6 +18,7 @@ export const getOptions = ({
   configuration,
   rpcURL,
   googleAnalyticsTag,
+  prod,
 }: {
   readonly network?: string;
   readonly port: number;
@@ -25,6 +26,7 @@ export const getOptions = ({
   readonly configuration: AssetsConfiguration;
   readonly rpcURL?: string;
   readonly googleAnalyticsTag: string;
+  readonly prod: boolean;
 }) =>
   getNetworkOptions({
     network,
@@ -34,6 +36,7 @@ export const getOptions = ({
       configuration,
       rpcURL,
       googleAnalyticsTag,
+      prod,
     }),
     test: test({
       port,
@@ -41,6 +44,7 @@ export const getOptions = ({
       configuration,
       rpcURL,
       googleAnalyticsTag,
+      prod,
     }),
     priv: priv({
       port,
@@ -48,5 +52,6 @@ export const getOptions = ({
       configuration,
       rpcURL,
       googleAnalyticsTag,
+      prod,
     }),
   });

--- a/packages/neotracker-core/src/options/main.ts
+++ b/packages/neotracker-core/src/options/main.ts
@@ -10,6 +10,7 @@ export const main = ({
   googleAnalyticsTag,
   url = 'https://neotracker.io',
   domain = 'neotracker.io',
+  prod,
 }: {
   readonly port: number;
   readonly db: LiteDBConfig | PGDBConfig | PGDBConfigString;
@@ -18,6 +19,7 @@ export const main = ({
   readonly googleAnalyticsTag: string;
   readonly url?: string;
   readonly domain?: string;
+  readonly prod: boolean;
 }) => {
   const db = isPGDBConfig(dbIn)
     ? {
@@ -30,6 +32,7 @@ export const main = ({
     : dbIn;
 
   return common({
+    prod,
     rpcURL,
     googleAnalyticsTag,
     url,

--- a/packages/neotracker-core/src/options/priv.ts
+++ b/packages/neotracker-core/src/options/priv.ts
@@ -8,12 +8,14 @@ export const priv = ({
   configuration,
   rpcURL = privRPCURL,
   googleAnalyticsTag,
+  prod,
 }: {
   readonly port: number;
   readonly db: LiteDBConfig | PGDBConfig | PGDBConfigString;
   readonly configuration: AssetsConfiguration;
   readonly rpcURL?: string;
   readonly googleAnalyticsTag: string;
+  readonly prod: boolean;
 }) => {
   const db = isPGDBConfig(dbIn)
     ? {
@@ -26,6 +28,7 @@ export const priv = ({
     : dbIn;
 
   return common({
+    prod,
     db,
     rpcURL,
     googleAnalyticsTag,

--- a/packages/neotracker-core/src/options/test.ts
+++ b/packages/neotracker-core/src/options/test.ts
@@ -8,12 +8,14 @@ export const test = ({
   configuration,
   rpcURL = testRPCURL,
   googleAnalyticsTag,
+  prod,
 }: {
   readonly port: number;
   readonly db: LiteDBConfig | PGDBConfig | PGDBConfigString;
   readonly configuration: AssetsConfiguration;
   readonly rpcURL?: string;
   readonly googleAnalyticsTag: string;
+  readonly prod: boolean;
 }) => {
   const db = isPGDBConfig(dbIn)
     ? {
@@ -26,6 +28,7 @@ export const test = ({
     : dbIn;
 
   return common({
+    prod,
     rpcURL,
     googleAnalyticsTag,
     port,


### PR DESCRIPTION
### Description of the Change

It appears that it is currently possible to connect to neotracker over HTTP. My suspicion for how HTTPS currently appears to be enforced is via the HSTS header, which we do currently set. See [here](https://helmetjs.github.io/docs/hsts/). Key text:

"The Strict-Transport-Security HTTP header tells browsers to stick with HTTPS and never visit the insecure HTTP version. Once a browser sees this header, it will only visit the site over HTTPS for the next 60 days. **Note that the header won’t tell users on HTTP to switch to HTTPS, it will just tell HTTPS users to stick around. You can enforce HTTPS with the express-enforces-ssl module.**"

Note that we are currently using a copy/pasted version of [this module](https://github.com/shlomisas/koa-sslify/blob/master/index.js) to enforce HTTPS redirects in this PR.

### Test Plan

Deploy to `staging` and allow HTTP connections to staging. Then test that you can't connect to the staging URL over HTTP with your browser, incognito browser, https://hstspreload.org/, and https://securityheaders.com/. And maybe verify the redirect with cURL.
