### PR TITLE
fix(https): update and enable https middleware

### DIFF
--- a/packages/neotracker-core/src/options/common.ts
+++ b/packages/neotracker-core/src/options/common.ts
@@ -77,7 +77,7 @@ export const common = ({
       smoothingFactor: 1 / 3,
     },
     security: {
-      enforceHTTPs: false,
+      enforceHTTPs: prod,
       frameguard: {
         enabled: true,
         action: 'deny',

--- a/packages/neotracker-server-utils-koa/src/middleware/context.ts
+++ b/packages/neotracker-server-utils-koa/src/middleware/context.ts
@@ -66,6 +66,7 @@ export const context = ({
     const logInfo: Record<string, string | number | undefined> = {
       title: 'http_server_request',
       ...ua.convertLabels(userAgent),
+      [Labels.HTTP_HEADERS]: JSON.stringify(ctx.headers),
     };
     const startTime = Date.now();
 

--- a/packages/neotracker-server-web/src/middleware/enforceHttps.ts
+++ b/packages/neotracker-server-web/src/middleware/enforceHttps.ts
@@ -69,6 +69,12 @@ export function enforceHTTPS(options: any) {
     // First, check if directly requested via https
     let secure = ctx.secure;
 
+    // Don't do redirect if request is coming from a load balancer health check (ie. GCE Ingress)
+    const isLoadBalancerHealthCheck = ctx.request.header['x-forwarded-proto'] == undefined ? true : false;
+    if (isLoadBalancerHealthCheck && options.trustProtoHeader) {
+      return next();
+    }
+
     // Second, if the request headers can be trusted (e.g. because they are send
     // by a proxy), check if x-forward-proto is set to https
     if (options.trustProtoHeader && ctx.request.header['x-forwarded-proto'] != undefined) {


### PR DESCRIPTION
### Description of the Change

Turns on HTTPS redirect middleware in production, adds HTTP headers logging earlier in middleware, and skips HTTPS redirect middleware if the request is coming from GCP Ingress (assumes all forwarded requests have `X-Forwarded-Proto` header, and health checks do not)

### Test Plan

Tested by building new image and deploying to staging cluster. This PR is _slightly_ different from what was tested, so this should still be merged and deployed to staging one last time to confirm.

### Issues

<!-- Enter any applicable Issues here -->
