### PR TITLE
fix(csp): minor fix to CSP to allow google-analytics

### DIFF
--- a/packages/neotracker-core/src/options/common.ts
+++ b/packages/neotracker-core/src/options/common.ts
@@ -93,7 +93,7 @@ export const common = ({
           formAction: ["'self'"],
           frameAncestors: ["'none'"],
           frameSrc: ["'self'", moonpayUrl],
-          imgSrc: ["'self'", 'data:'],
+          imgSrc: ["'self'", 'data:', 'https://www.google-analytics.com', 'https://stats.g.doubleclick.net'],
           manifestSrc: ["'self'"],
           mediaSrc: ["'self'"],
           objectSrc: ["'none'"],


### PR DESCRIPTION
### Description of the Change

I inadvertently noticed that the browser was blocking `www.google-analytics.com` due to our CSP. I didn't notice this before due to browser extensions I have that blocked it before the CSP could.

<img width="1261" alt="Screen Shot 2020-04-21 at 4 19 22 PM" src="https://user-images.githubusercontent.com/29364457/79924665-36e9c800-83ed-11ea-94e5-5ced2976733c.png">

### Test Plan

Tested locally. It works.