### PR TITLE
fix(ecosystem): add security/privacy to ecosystem

### DIFF
--- a/packages/neotracker-shared-web/src/components/ecosystem/common/EcosystemCard.js
+++ b/packages/neotracker-shared-web/src/components/ecosystem/common/EcosystemCard.js
@@ -98,7 +98,7 @@ function EcosystemCard({
   cover,
 }: Props): React.Element<any> {
   const openLink = () => {
-    window.open(link, '_blank');
+    window.open(link, '_blank', 'noreferrer,noopener');
   };
   return (
     <div


### PR DESCRIPTION
### Description of the Change

Adds the `rel=noreferrer` and `rel=noopener` to the links on the `Ecosystem` page for security and privacy protections. See [here](https://developers.google.com/web/tools/lighthouse/audits/noopener)

### Test Plan

Tested locally.
