### PR TITLE
fix(logging): add error log to doExecuteForDocument

### DIFF
--- a/packages/neotracker-server-graphql/src/createQueryDeduplicator.ts
+++ b/packages/neotracker-server-graphql/src/createQueryDeduplicator.ts
@@ -60,6 +60,16 @@ export async function doExecuteForDocument({
 }): Promise<ExecutionResult> {
   try {
     const response = await execute(schema, doc, rootValue, context, variables);
+    if (response.errors !== undefined && response.errors.length > 0) {
+      serverLogger.error({
+        title: 'graphql_top_level_execute_response_errors',
+        doc,
+        variables,
+        schema,
+        rootValue,
+        context,
+      });
+    }
 
     return convertExecutionResult(response);
   } catch (error) {

--- a/packages/neotracker-server-graphql/src/live/LiveServer.ts
+++ b/packages/neotracker-server-graphql/src/live/LiveServer.ts
@@ -474,6 +474,7 @@ export class LiveServer {
         ...handleConnectionLabels,
         title: 'websocket_server_message_received',
         [utilLabels.WEBSOCKET_MESSAGE_TYPE]: message.type,
+        [utilLabels.WEBSOCKET_MESSAGEJSON]: messageJSON,
       });
 
       // tslint:disable-next-line no-floating-promises

--- a/root/robots.txt
+++ b/root/robots.txt
@@ -1,2 +1,3 @@
 User-agent: *
 Allow: /
+Crawl-delay: 1


### PR DESCRIPTION
### Description of the Change

Adds a strategic log in `createQueryDeduplicator.ts` for when a GQL query execution returns errors. Note that this is not when the document execution _throws_ errors, but when the query itself _returns_ errors. This should add a flood of information in the logs when we get a `graphql_execute_error` response.

This changes the `robots.txt` file to add the `Crawl-delay` directive, which will slow down the requests of most honest web-crawler bots. This may also help mitigate the crashing server pods problem for now.

### Test Plan

Deploy to `prod` cluster.

### Issues

#169 