### PR TITLE
fix(husky): remove FlowJS git hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -200,7 +200,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "lint-staged && echo \"Executing tsc...\" && yarn run tsc && yarn run flow",
+      "pre-commit": "lint-staged && echo \"Executing tsc...\" && yarn run tsc",
       "post-checkout": "cross-env-shell \"yarn run ts-node ./scripts/hooks/post-checkout.ts $HUSKY_GIT_PARAMS\"",
       "post-merge": "yarn run ts-node ./scripts/hooks/post-merge.ts",
       "post-rewrite": "yarn run ts-node ./scripts/hooks/post-rewrite.ts"


### PR DESCRIPTION
### Description of the Change

We ignore this anyway, so let's remove it so that we don't get used to running `git commit --no-verify`. We need to keep using the other git hooks.

### Test Plan

Flow check didn't run when I made this commit.
