### PR TITLE
fix(logo): fix logo title nit

### DIFF
--- a/packages/neotracker-shared-web/src/components/common/logo/Logo.js
+++ b/packages/neotracker-shared-web/src/components/common/logo/Logo.js
@@ -37,7 +37,7 @@ function Logo({ width, height, white, className }: Props): React.Element<*> {
     >
       <defs>{style}</defs>
       <g>
-        <title>Layer 1</title>
+        <title>NEO Tracker Logo</title>
         <g stroke="null" id="Layer_2">
           <g stroke="null" id="svg_5">
             <polygon

--- a/packages/neotracker-shared-web/src/components/common/logo/TitleLogo.js
+++ b/packages/neotracker-shared-web/src/components/common/logo/TitleLogo.js
@@ -33,7 +33,7 @@ function TitleLogo({ id }: Props): React.Element<*> {
         NEO Tracker Blockchain Explorer & Wallet
       </desc>
       <g>
-        <title>Layer 1</title>
+        <title>NEO Tracker Logo</title>
         <g stroke="null" id="Layer_2">
           <g stroke="null" id="svg_5">
             <polygon


### PR DESCRIPTION
### Description of the Change

This is a super nit, but if you hover your mouse of the current NEO Tracker logo it will show the title as "Layer 1". I think we want that to show "NEO Tracker Logo". This `title` attribute is primarily for accessibility purposes so that a screen-reader can describe the object to the user. See [here](https://www.sitepoint.com/tips-accessible-svg/). This is why it should be "NEO Tracker Logo" and not just "NEO Tracker".

<img width="379" alt="Screen Shot 2020-05-09 at 6 37 11 PM" src="https://user-images.githubusercontent.com/29364457/81489017-a3eec180-9225-11ea-8122-7150e8561260.png">

### Test Plan

Tested locally.