### PR TITLE
feat(testnet): add config option for testnet

### DIFF
--- a/packages/neotracker-core/src/options/index.ts
+++ b/packages/neotracker-core/src/options/index.ts
@@ -57,6 +57,21 @@ export const getOptions = (
         prod,
       });
 
+    case 'test':
+      return common({
+        rpcURL: rpcURL ? rpcURL : testRPCURL,
+        url: 'https://testnet.neotracker.io',
+        domain: 'testnet.neotracker.io',
+        blacklistNEP5Hashes: [
+          'ee0515b2a3d24873e7e0d27426af9c99bbd3fdd2', // AnkarenkoToken
+          'cb8f7f52183225d86ef7af1274ec00834b9edfca', // Test World Token4
+        ],
+        db,
+        configuration,
+        googleAnalyticsTag,
+        prod,
+      });
+
     case 'staging':
       return common({
         rpcURL: rpcURL ? rpcURL : mainRPCURL,

--- a/packages/neotracker-shared-utils/src/types.ts
+++ b/packages/neotracker-shared-utils/src/types.ts
@@ -20,4 +20,4 @@ export interface AppOptions {
   readonly bsaEnabled?: boolean;
   readonly debug: boolean;
 }
-export type NetworkType = 'main' | 'staging' | 'priv';
+export type NetworkType = 'main' | 'staging' | 'priv' | 'test';

--- a/packages/neotracker-shared-web/src/components/explorer/contract/ContractTable.js
+++ b/packages/neotracker-shared-web/src/components/explorer/contract/ContractTable.js
@@ -20,6 +20,7 @@ const styles = () => ({
   nameValue: {
     flex: '1 1 auto',
     minWidth: 136,
+    maxWidth: 260,
   },
   authorValue: {
     flex: '1 10 auto',


### PR DESCRIPTION
### Description of the Change

Adds a network config option for a TestNet version of NT.

This includes some blacklisted NEP5 contracts that caused a problem with the scraper due to crazy `precision` attributes, for example `2.2391003503011755e+33`. See logs with the error and my debug log:
<img width="2560" alt="Screen Shot 2020-05-10 at 7 12 56 PM" src="https://user-images.githubusercontent.com/29364457/81520275-b259dd80-92f8-11ea-9e8b-f20bbedade7f.png">

### Test Plan

This will be tested when deployed to a new `testnet` cluster.

### Issues

#161