### PR TITLE
fix(pubsub): remove Promise.race in pubsub

### DIFF
--- a/packages/neotracker-server-db/src/createPubSub.ts
+++ b/packages/neotracker-server-db/src/createPubSub.ts
@@ -88,21 +88,13 @@ const createPGPubSub = <T>({
     }
   };
 
-  const attemptClientEnd = (termClient: Client) =>
-    Promise.race([
-      new Promise<void>((resolve) => {
-        setTimeout(resolve, 5000);
-      }),
-      termClient.end(),
-    ]);
-
   const closeClient = async () => {
     const currentClient = client;
     client = createClient();
     connected = false;
     try {
       currentClient.removeAllListeners();
-      await attemptClientEnd(currentClient);
+      await currentClient.end();
     } catch (error) {
       serverDBLogger.error({ title: 'pg_pubsub_close_error', error: error.message });
     }


### PR DESCRIPTION
### Description of the Change

Reverts #98. We thought that this apparently issue with the NodeJS client library not closing/releasing connections to the DB was causing the problems in #169. When I went to reproduce the issue that #98 supposedly solved I couldn't recreate that issue. So we're reverting #98 here since it's apparently not an issue anymore and with the hope that it solves the problems in #169.

### Test Plan

Deployed to local K8s cluster- no problems. Deployed to staging cluster- no problems. Deployed to prod cluster- no problems.

### Issues

#99 
#169
