### PR TITLE
fix(middleware): enable rateLimit, tooBusy middleware

### DIFF
--- a/packages/neotracker-core/src/options/common.ts
+++ b/packages/neotracker-core/src/options/common.ts
@@ -43,7 +43,7 @@ export const common = ({
     },
     subscribeProcessedNextIndex: { db },
     rateLimit: {
-      enabled: false,
+      enabled: true,
       config: {
         rate: 5 * 60, // Allow 5 requests per second
         duration: 60 * 1000, // 60 seconds
@@ -65,7 +65,7 @@ export const common = ({
       rpcURL,
     },
     toobusy: {
-      enabled: false,
+      enabled: true,
       userAgents,
       whitelistedUserAgents,
       maxLag: 70,


### PR DESCRIPTION
### Description of the Change

Not sure why we turned these off in the first place, but they should be enabled.

### Test Plan

Watch for problems when we deploy next, but it should be perfectly fine.