### PR TITLE
fix(csp): add google-analytics to script-src

### DIFF
--- a/packages/neotracker-core/src/options/common.ts
+++ b/packages/neotracker-core/src/options/common.ts
@@ -93,7 +93,12 @@ export const common = ({
           manifestSrc: ["'self'"],
           mediaSrc: ["'self'"],
           objectSrc: ["'none'"],
-          scriptSrc: ["'self'", "'unsafe-eval'", 'https://www.googletagmanager.com'],
+          scriptSrc: [
+            "'self'",
+            "'unsafe-eval'",
+            'https://www.googletagmanager.com',
+            'https://www.google-analytics.com',
+          ],
           styleSrc: ["'self'", "'unsafe-inline'", 'https://fonts.googleapis.com'],
           upgradeInsecureRequests: true,
           workerSrc: ["'self'"],


### PR DESCRIPTION
### Description of the Change

Noticed that a script was being blocked in Safari and Firefox while looking at something else. For some reason it's not blocked in Google Chrome, but it should be based on our current CSP. So this just updates the CSP to allow a script to be loaded in Safari and Firefox, possibly other browsers.