### PR TITLE
fix(robots): block mj12 crawler

### DIFF
--- a/root/robots.txt
+++ b/root/robots.txt
@@ -1,2 +1,5 @@
 User-agent: *
 Allow: /
+
+User-agent: MJ12bot
+Disallow: /


### PR DESCRIPTION
### Description of the Change

Finalizes the work done to fix the crashing web server pods. After reverting the PubSub `Promse.race` everything worked fine for about 24 hours before it appeared that one bot, `MJ12bot` was doing something to still crash the pods repeatedly. This just blocks that one bot, which has been working for several days now without a glitch.

### Test Plan

Deployed to prod cluster with no issues.

### Issues

#169
