### PR TITLE
Revert "fix(robots): block megaindex crawler"

### DIFF
--- a/root/robots.txt
+++ b/root/robots.txt
@@ -3,12 +3,3 @@ Allow: /
 
 User-agent: MJ12bot
 Disallow: /
-
-User-agent: MegaIndex.ru/2.0
-Disallow: /
-
-User-agent: MegaIndex.ru
-Disallow: /
-
-User-agent: megaIndex.ru
-Disallow: /


### PR DESCRIPTION
### Description of the Change

This reverts commit af238fdaca3c655acfb0654b4a42b84dabccb422. Apparently trying to block the MegaIndex agent didn't work, so I'm reverting this. I think the problem has to do with resource allocation in Kubernetes.

### Test Plan

Already deployed.

### Issues

#169