### PR TITLE
fix(rpx): temporary fix for RPX token bug

### DIFF
--- a/packages/neotracker-server-db/src/models/Coin.ts
+++ b/packages/neotracker-server-db/src/models/Coin.ts
@@ -101,7 +101,7 @@ export class Coin extends BlockchainModel<string> {
         },
       },
 
-      required: true,
+      required: false, // false for RPX token
       exposeGraphQL: true,
     },
   };

--- a/packages/neotracker-server-db/src/models/Transfer.ts
+++ b/packages/neotracker-server-db/src/models/Transfer.ts
@@ -146,7 +146,7 @@ export class Transfer extends BlockchainModel<string> {
       },
 
       exposeGraphQL: true,
-      required: true,
+      required: false, // false for RPX token
     },
 
     action: {

--- a/packages/neotracker-server-graphql/src/__generated__/schema.graphql
+++ b/packages/neotracker-server-graphql/src/__generated__/schema.graphql
@@ -236,7 +236,7 @@ type Coin implements Node {
   asset_id: String!
   value: String!
   address: Address!
-  asset: Asset!
+  asset: Asset
 }
 
 type Contract implements Node {
@@ -542,7 +542,7 @@ type Transfer implements Node {
   to_address_id: String
   block_time: Int!
   transaction: Transaction
-  asset: Asset!
+  asset: Asset
   action: Action!
   contract: Contract!
   from_address: Address

--- a/packages/neotracker-server-graphql/src/__generated__/schema.graphql.json
+++ b/packages/neotracker-server-graphql/src/__generated__/schema.graphql.json
@@ -4144,13 +4144,9 @@
               "description": "",
               "args": [],
               "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "OBJECT",
-                  "name": "Asset",
-                  "ofType": null
-                }
+                "kind": "OBJECT",
+                "name": "Asset",
+                "ofType": null
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -5379,13 +5375,9 @@
               "description": "",
               "args": [],
               "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "OBJECT",
-                  "name": "Asset",
-                  "ofType": null
-                }
+                "kind": "OBJECT",
+                "name": "Asset",
+                "ofType": null
               },
               "isDeprecated": false,
               "deprecationReason": null

--- a/packages/neotracker-shared-utils/src/constants.ts
+++ b/packages/neotracker-shared-utils/src/constants.ts
@@ -24,3 +24,4 @@ export const GAS_COIN_ASSET = {
 };
 
 export const MINIMUM_NETWORK_FEE = 0.001;
+export const UNKNOWN_COIN = { id: 'N/A', symbol: 'N/A' };

--- a/packages/neotracker-shared-web/src/components/explorer/action/lib/__generated__/TransferItem_transfer.graphql.js
+++ b/packages/neotracker-shared-web/src/components/explorer/action/lib/__generated__/TransferItem_transfer.graphql.js
@@ -15,7 +15,7 @@ export type TransferItem_transfer = {|
   +from_address_id: ?string,
   +to_address_id: ?string,
   +value: string,
-  +asset: {|
+  +asset: ?{|
     +$fragmentRefs: AssetNameLink_asset$ref
   |},
   +$refType: TransferItem_transfer$ref,

--- a/packages/neotracker-shared-web/src/components/explorer/address/__generated__/AddressView_address.graphql.js
+++ b/packages/neotracker-shared-web/src/components/explorer/address/__generated__/AddressView_address.graphql.js
@@ -22,7 +22,7 @@ export type AddressView_address = {|
     +edges: $ReadOnlyArray<{|
       +node: {|
         +value: string,
-        +asset: {|
+        +asset: ?{|
           +id: string,
           +symbol: string,
         |},

--- a/packages/neotracker-shared-web/src/components/explorer/address/lib/__generated__/CoinTable_coins.graphql.js
+++ b/packages/neotracker-shared-web/src/components/explorer/address/lib/__generated__/CoinTable_coins.graphql.js
@@ -12,7 +12,7 @@ import type { FragmentReference } from "relay-runtime";
 declare export opaque type CoinTable_coins$ref: FragmentReference;
 export type CoinTable_coins = $ReadOnlyArray<{|
   +value: string,
-  +asset: {|
+  +asset: ?{|
     +id: string,
     +symbol: string,
   |},

--- a/packages/neotracker-shared-web/src/components/explorer/address/lib/__generated__/Coin_coin.graphql.js
+++ b/packages/neotracker-shared-web/src/components/explorer/address/lib/__generated__/Coin_coin.graphql.js
@@ -12,7 +12,7 @@ import type { FragmentReference } from "relay-runtime";
 declare export opaque type Coin_coin$ref: FragmentReference;
 export type Coin_coin = {|
   +value: string,
-  +asset: {|
+  +asset: ?{|
     +id: string,
     +symbol: string,
   |},

--- a/packages/neotracker-shared-web/src/components/explorer/address/lib/getSortedCoins.js
+++ b/packages/neotracker-shared-web/src/components/explorer/address/lib/getSortedCoins.js
@@ -8,19 +8,24 @@ import {
   GAS_ASSET_HASH,
   NEO_COIN_ASSET,
   GAS_COIN_ASSET,
+  UNKNOWN_COIN,
   // $FlowFixMe
 } from '@neotracker/shared-utils';
 
 import { getID } from '../../../../graphql/relay';
 
 export default (
-  coins: $ReadOnlyArray<{
+  coinsIn: $ReadOnlyArray<{
     +asset: {
       +id: string,
     },
     +value: string,
   }>,
 ) => {
+  const coins = coinsIn.map((coin) => ({
+    ...coin,
+    asset: coin.asset || UNKNOWN_COIN,
+  }));
   let result = _.partition(
     coins,
     (coin) => getID(coin.asset.id) === NEO_ASSET_HASH,

--- a/packages/neotracker-shared-web/src/components/explorer/asset/lib/AssetNameLinkBase.js
+++ b/packages/neotracker-shared-web/src/components/explorer/asset/lib/AssetNameLinkBase.js
@@ -1,6 +1,7 @@
 /* @flow */
 import * as React from 'react';
 import type { Variant } from '@material-ui/core/Typography';
+import { UNKNOWN_COIN } from '@neotracker/shared-utils';
 
 import { type HOC, compose, pure } from 'recompose';
 
@@ -25,12 +26,13 @@ type Props = {|
   ...InternalProps,
 |};
 function AssetNameLinkBase({
-  asset,
+  asset: assetIn,
   variant: variantIn,
   component,
   className,
 }: Props): React.Element<*> {
   const variant = variantIn == null ? 'body1' : variantIn;
+  const asset = assetIn || UNKNOWN_COIN;
   return (
     <Link
       className={className}

--- a/packages/neotracker-shared-web/src/components/explorer/transaction/summary/__generated__/TransactionInvocationSummaryBody_transaction.graphql.js
+++ b/packages/neotracker-shared-web/src/components/explorer/transaction/summary/__generated__/TransactionInvocationSummaryBody_transaction.graphql.js
@@ -22,7 +22,7 @@ export type TransactionInvocationSummaryBody_transaction = {|
   +transfers: {|
     +edges: $ReadOnlyArray<{|
       +node: {|
-        +asset: {|
+        +asset: ?{|
           +$fragmentRefs: AssetNameLink_asset$ref
         |},
         +from_address_id: ?string,

--- a/packages/neotracker-shared-web/src/components/explorer/transfer/__generated__/TransferTable_transfers.graphql.js
+++ b/packages/neotracker-shared-web/src/components/explorer/transfer/__generated__/TransferTable_transfers.graphql.js
@@ -16,7 +16,7 @@ export type TransferTable_transfers = $ReadOnlyArray<{|
   +from_address_id: ?string,
   +to_address_id: ?string,
   +value: string,
-  +asset: {|
+  +asset: ?{|
     +$fragmentRefs: AssetNameLink_asset$ref
   |},
   +block_time: number,

--- a/packages/neotracker-shared-web/src/components/faq/GeneralFAQView.js
+++ b/packages/neotracker-shared-web/src/components/faq/GeneralFAQView.js
@@ -93,13 +93,14 @@ possibility something unexpected happens that causes your funds to be lost.
 Please do not invest more than you are willing to lose, and please be careful.
 `;
 
-const RPXQuestion = `
-## An Address I want to see is seemingly loading forever. What's going on?
-We are aware of a bug in NEO Tracker that causes this error on addresses that have the
-RPX (Red Pulse Phoenix) token. This is an issue with NEO Tracker and not with the Neo blockchain, RPX token,
-or that Address. This is currently our top priority to fix and will be fixed soon.
-If you think something else is wrong or you are still concerned please reach out to us on
-[Twitter](https://twitter.com/neotrackerio) or [Facebook](https://www.facebook.com/neotracker.io/).
+const RPXToken = `
+## What token is represented by "N/A"?
+"N/A" typically means "not applicable", "not available", or "no answer".
+In the case of NEO Tracker this likely represents the old RPX (Red Pulse Phoenix) token, which
+was swapped for the PHX token in 2018. The RPX token no longer exists, but RPX token transactions
+still exist on the blockchain, which means that NEO Tracker still reads and stores those
+token transactions and token balances. So if you see "N/A" in your wallet or in transactions
+just know that it probably represents transactions and balances of the old RPX token.
 `;
 
 const GeneralFAQ = `
@@ -190,7 +191,7 @@ or Block index.
 `;
 
 const FAQ = `
-${RPXQuestion}
+${RPXToken}
 ${CoreWalletFAQ}
 ${GeneralFAQ}
 ${Disclaimer}

--- a/packages/neotracker-shared-web/src/components/wallet/account/__generated__/SendTransaction_address.graphql.js
+++ b/packages/neotracker-shared-web/src/components/wallet/account/__generated__/SendTransaction_address.graphql.js
@@ -15,7 +15,7 @@ export type SendTransaction_address = {|
     +edges: $ReadOnlyArray<{|
       +node: {|
         +value: string,
-        +asset: {|
+        +asset: ?{|
           +type: string,
           +id: string,
           +precision: number,

--- a/packages/neotracker-shared-web/src/pages/__generated__/AddressSearchQuery.graphql.js
+++ b/packages/neotracker-shared-web/src/pages/__generated__/AddressSearchQuery.graphql.js
@@ -1,6 +1,6 @@
 /**
  * @flow
- * @relayHash 19eba039c46d8cbafd5e030d2c4041fb
+ * @relayHash 82a8dc56316e86989bed721fd661ce38
  */
 
 /* eslint-disable */
@@ -24,7 +24,7 @@ export type AddressSearchQueryResponse = {|
           +edges: $ReadOnlyArray<{|
             +node: {|
               +value: string,
-              +asset: {|
+              +asset: ?{|
                 +id: string,
                 +symbol: string,
               |},


### PR DESCRIPTION
### Description of the Change

Temporarily fixes the RPX token issue. It looks like this issue isn't actually as bad as we assumed. It doesn't seem that it's an issue with contract storage, but probably an issue with the token migration. I say this because it looks like we still have correct balances and such with the RPX token, it's just that the token is missing ID and Symbol information in the DB.

So to fix this I basically turned off the associated `required` fields in the GQL server. So when GQL sees that it's gotten a mismatched type from the PG DB it won't freak out. BUT this means that it will be returning an unexpected value: `null` to the front-end. So you see I've handled that by basically using a default value anywhere that we try to use `coin.asset` (only two places).

I left a comment in the two `required: false` fields so that we know that those fields should be reverted back to `true` at a later date when we fix that transfer in the DB.

For a visual into the values being returned from the GQL server now see these:
<img width="798" alt="Screen Shot 2020-06-06 at 9 08 03 PM" src="https://user-images.githubusercontent.com/29364457/83961218-df40d800-a845-11ea-9d33-53ed827c3192.png">
<img width="799" alt="Screen Shot 2020-06-06 at 9 46 30 PM" src="https://user-images.githubusercontent.com/29364457/83961220-e0720500-a845-11ea-9d2d-fd940581c20b.png">

### Test Plan

It's currently deployed to staging and it works great. See the screenshots here as proof. Note that I changed it to say "Unknown Coin" uppercased. The screenshots I took were from a previous version that were "Unknown coin". For example check what happens now on NT [here](https://neotracker.io/address/ATgiAKdLvxiiDnwiom3TWXHLtfXfH4KDJb). And then see how the same address looks now on staging [here](https://staging.neotracker.io/address/ATgiAKdLvxiiDnwiom3TWXHLtfXfH4KDJb).

You can do the same with a transaction. On NT [now](https://neotracker.io/tx/33424afc0417fe973293a0b94604076bd04d073ff35bea39d676852a2218452b) vs on staging [now](https://staging.neotracker.io/tx/33424afc0417fe973293a0b94604076bd04d073ff35bea39d676852a2218452b).

An address known to have RPX:
<img width="1044" alt="Screen Shot 2020-06-06 at 10 03 12 PM" src="https://user-images.githubusercontent.com/29364457/83961245-17481b00-a846-11ea-9446-3b068f8d6541.png">

An RPX transfer in that address:
<img width="1048" alt="Screen Shot 2020-06-06 at 10 03 07 PM" src="https://user-images.githubusercontent.com/29364457/83961246-19aa7500-a846-11ea-8fb2-229e84b1781e.png">

Assets in that address:
<img width="1068" alt="Screen Shot 2020-06-06 at 10 03 00 PM" src="https://user-images.githubusercontent.com/29364457/83961248-1b743880-a846-11ea-9601-aeaafd53c1f5.png">

A RPX transaction that would normally just load forever in NT:
<img width="1048" alt="Screen Shot 2020-06-06 at 10 03 43 PM" src="https://user-images.githubusercontent.com/29364457/83961249-1dd69280-a846-11ea-9e7c-d984d067fb2e.png">


### Issues

#131