### PR TITLE
fix(knex): pin knex dependency for neo-one

### DIFF
--- a/packages/neotracker-server-db/package.json
+++ b/packages/neotracker-server-db/package.json
@@ -20,7 +20,7 @@
     "change-case": "^3.0.2",
     "dataloader": "^1.4.0",
     "graphql": "14.5.8",
-    "knex": "^0.20.8",
+    "knex": "0.20.8",
     "lodash": "^4.17.11",
     "lru-cache": "^4.1.1",
     "objection": "^1.4.0",

--- a/packages/neotracker-server-scrape-check/package.json
+++ b/packages/neotracker-server-scrape-check/package.json
@@ -13,7 +13,7 @@
     "@neotracker/server-db": "^0.0.1-alpha.0",
     "@neotracker/shared-utils": "^0.0.1-alpha.0",
     "bignumber.js": "^9.0.0",
-    "knex": "^0.20.8",
+    "knex": "0.20.8",
     "lodash": "^4.17.11"
   },
   "sideEffects": false

--- a/packages/neotracker-server-scrape/package.json
+++ b/packages/neotracker-server-scrape/package.json
@@ -15,7 +15,7 @@
     "@neotracker/shared-utils": "^0.0.1-alpha.0",
     "bignumber.js": "^9.0.0",
     "ix": "^2.5.3",
-    "knex": "^0.20.8",
+    "knex": "0.20.8",
     "lodash": "^4.17.11",
     "lru-cache": "^4.1.1",
     "objection": "^1.4.0",

--- a/packages/neotracker-server-test/package.json
+++ b/packages/neotracker-server-test/package.json
@@ -18,7 +18,7 @@
     "fs-extra": "^7.0.1",
     "jest-environment-jsdom": "23.4.0",
     "jest-environment-node": "23.4.0",
-    "knex": "^0.20.8",
+    "knex": "0.20.8",
     "sqlite3": "4.0.4",
     "tmp": "^0.0.33",
     "uuid": "^3.3.2",


### PR DESCRIPTION
### Description of the Change

Pin `knex` dependency to make NEO Tracker work in NEO•ONE repo.

### Test Plan

Published alpha version of NT, then used in NEO•ONE.