### PR TITLE
fix(memory): increase nodejs max memory in docker image

### DIFF
--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -81,4 +81,4 @@ COPY --from=builder tmp/neotracker/dist/neotracker-core/ neotracker-core/
 COPY yarn.lock neotracker-core/
 WORKDIR /neotracker-core
 RUN yarn install --production
-ENTRYPOINT ["/usr/local/bin/node", "bin/neotracker", "neotracker"]
+ENTRYPOINT ["/usr/local/bin/node", "--max-old-space-size=1024","bin/neotracker", "neotracker"]


### PR DESCRIPTION
### Description of the Change

Same as title. This is not necessarily a permanent fix if there's a memory leak though. Time will give us more info.

### Test Plan

Deployed to prod cluster and no pod restarts in 24 hours.

### Issues

#225 