### PR TITLE
fix(tokens): fix broken LONG and RPX tokens with migrations

### DIFF
--- a/packages/neotracker-build/src/entry/server.ts
+++ b/packages/neotracker-build/src/entry/server.ts
@@ -7,7 +7,7 @@ import { configuration } from '../configuration';
 const {
   port,
   network: neotrackerNetwork,
-  nodeRpcUrl,
+  nodeRpcUrl: rpcURL,
   metricsPort = 1341,
   db,
   type,
@@ -20,21 +20,6 @@ const {
 });
 
 const { googleAnalyticsTag, moonpayPublic: moonpayPublicApiKey } = apiKeys;
-
-let rpcURL: string | undefined;
-switch (neotrackerNetwork) {
-  case 'priv':
-    rpcURL = nodeRpcUrl;
-    if (rpcURL === undefined) {
-      rpcURL = 'http://localhost:9040/rpc';
-    }
-    break;
-  case 'main':
-    rpcURL = 'https://neotracker.io/rpc';
-    break;
-  default:
-    rpcURL = 'https://testnet.neotracker.io/rpc';
-}
 
 const options = getOptions(neotrackerNetwork, {
   port,

--- a/packages/neotracker-server-scrape/src/MigrationHandler.ts
+++ b/packages/neotracker-server-scrape/src/MigrationHandler.ts
@@ -1,6 +1,5 @@
 import { createTables, makeAllPowerfulQueryContext, Migration, QueryContext } from '@neotracker/server-db';
 import Knex from 'knex';
-import { migrations } from './migrations';
 
 export class MigrationHandler {
   private readonly enabled: boolean;
@@ -38,8 +37,6 @@ export class MigrationHandler {
 
       const initMigration = await this.getMigration('initialization');
       if (initMigration === undefined || !initMigration.complete) {
-        await Promise.all(migrations.map(async ([migrationName]) => this.onComplete(migrationName)));
-
         await this.onComplete('initialization');
       }
 

--- a/packages/neotracker-server-scrape/src/createScraper$.ts
+++ b/packages/neotracker-server-scrape/src/createScraper$.ts
@@ -232,9 +232,10 @@ export const createScraper$ = ({
     }),
     mergeScanLatest<Context, Context>(async (_acc, context: Context) => {
       // tslint:disable-next-line no-loop-statement
-      for (const [name, migration] of migrations) {
-        const execute = await context.migrationHandler.shouldExecute(name);
-        if (execute) {
+      for (const [name, migration, shouldMigrate] of migrations) {
+        const shouldExecute = await context.migrationHandler.shouldExecute(name);
+        const shouldDoMigration = await shouldMigrate(context);
+        if (shouldExecute && shouldDoMigration) {
           await migration(context, name);
           await context.migrationHandler.onComplete(name);
         }

--- a/packages/neotracker-server-scrape/src/migrations/index.ts
+++ b/packages/neotracker-server-scrape/src/migrations/index.ts
@@ -1,7 +1,133 @@
+import { ConfirmedInvocationTransaction } from '@neo-one/client-full';
+import {
+  Asset as AssetModel,
+  Coin as CoinModel,
+  ProcessedIndex as ProcessedIndexModel,
+  Transfer as TransferModel,
+} from '@neotracker/server-db';
 import { Context } from '../types';
 
 export type MigrationName = string;
 export type MigrationFunc = (context: Context, name: string) => Promise<void>;
+export type ShouldMigrateFunc = (context: Context) => Promise<boolean>;
+
+const getAssetData = async ({
+  context,
+  assetHash,
+  transactionHash,
+  blockIndex,
+}: {
+  readonly context: Context;
+  readonly assetHash: string;
+  readonly transactionHash: string;
+  readonly blockIndex: number;
+}) => {
+  const [issuedAndAmount, addressCount, transferCount, lastProcessedIndex, block] = await Promise.all([
+    CoinModel.query(context.db)
+      .context(context.makeQueryContext())
+      .sum('value')
+      .where('asset_id', assetHash)
+      .first(),
+    CoinModel.query(context.db)
+      .context(context.makeQueryContext())
+      .count('address_id')
+      .where('asset_id', assetHash)
+      .first(),
+    TransferModel.query(context.db)
+      .context(context.makeQueryContext())
+      .count('id')
+      .where('asset_id', assetHash)
+      .first(),
+    ProcessedIndexModel.query(context.db)
+      .context(context.makeQueryContext())
+      .max('index')
+      .first(),
+    context.client.getBlock(blockIndex),
+  ] as const);
+  const transaction = block.transactions.filter((trans) => trans.hash === `0x${transactionHash}`)[0];
+  const contract = (transaction as ConfirmedInvocationTransaction).invocationData.contracts[0];
+
+  return {
+    id: assetHash,
+    transaction_id: transaction.receipt.globalIndex.toString(),
+    transaction_hash: transactionHash,
+    // tslint:disable-next-line: no-any
+    amount: (issuedAndAmount as any).sum as string,
+    block_time: block.time,
+    // tslint:disable-next-line: no-any
+    issued: (issuedAndAmount as any).sum as string,
+    // tslint:disable-next-line: no-any
+    address_count: (addressCount as any).count as string,
+    // tslint:disable-next-line: no-any
+    transfer_count: (transferCount as any).count as string,
+    // tslint:disable-next-line: no-any
+    aggregate_block_id: (lastProcessedIndex as any).max as number,
+    owner: contract.author,
+    admin_address_id: contract.address,
+  };
+};
+
+const migrationBlockAboveCurrentBlock = async ({
+  context,
+  migrationBlock,
+}: {
+  readonly context: Context;
+  readonly migrationBlock: number;
+}) => {
+  const lastBlock = await ProcessedIndexModel.query(context.db)
+    .context(context.makeQueryContext())
+    .max('index')
+    .first();
+
+  // tslint:disable-next-line: no-any
+  return lastBlock === undefined ? false : ((lastBlock as any).max as number) >= migrationBlock;
+};
+
+const rpxMigrationBlock = 1444840;
+const longMigrationBlock = 5752874;
 
 // tslint:disable-next-line export-name
-export const migrations: ReadonlyArray<readonly [string, MigrationFunc]> = [];
+export const migrations: ReadonlyArray<readonly [string, MigrationFunc, ShouldMigrateFunc]> = [
+  [
+    'RPX',
+    async (context, _) => {
+      const assetHash = 'ecc6b20d3ccac1ee9ef109af5a7cdb85706b1df9';
+      const transactionHash = 'c8c9696476091fd63f4b0214715abe3eb10f4882a2959d4592c1f3cace800c24';
+      const blockIndex = rpxMigrationBlock;
+      const assetData = await getAssetData({ context, blockIndex, assetHash, transactionHash });
+
+      await AssetModel.insertAll(context.db, context.makeQueryContext(), [
+        {
+          ...assetData,
+          type: 'NEP5',
+          name_raw: 'RPX Sale',
+          symbol: 'RPX',
+          precision: 8,
+          transaction_count: '-1', // not possible to get w/o resync
+        },
+      ]);
+    },
+    async (context) => migrationBlockAboveCurrentBlock({ context, migrationBlock: rpxMigrationBlock }),
+  ],
+  [
+    'LONG',
+    async (context, _) => {
+      const assetHash = 'c3361fef35233f9db6354b259be9cde34ba667c5';
+      const transactionHash = '3f2688208983c72d530233df6a171583457805825023d9d19279d7114fea5f48';
+      const blockIndex = longMigrationBlock;
+      const assetData = await getAssetData({ context, blockIndex, transactionHash, assetHash });
+
+      await AssetModel.insertAll(context.db, context.makeQueryContext(), [
+        {
+          ...assetData,
+          type: 'NEP5',
+          name_raw: 'LONG',
+          symbol: 'LONG',
+          precision: 8,
+          transaction_count: '632681', // per NEOSCAN on 08/03/20 15:19PDT
+        },
+      ]);
+    },
+    async (context) => migrationBlockAboveCurrentBlock({ context, migrationBlock: longMigrationBlock }),
+  ],
+];

--- a/packages/neotracker-shared-web/src/components/exchange/common/PoweredByMoonPay.js
+++ b/packages/neotracker-shared-web/src/components/exchange/common/PoweredByMoonPay.js
@@ -39,6 +39,7 @@ const points = [
   'Press "Buy Now" again and you\'ll be asked for an email address.',
   `Once your transaction is completed on MoonPay's site you'll be redirected back to NEO Tracker to see your transaction reflected on the Neo blockchain.`,
   'U.S. users cannot currently purchase NEO from MoonPay.',
+  'If you experience any issues with the MoonPay widget please message us on Twitter or Facebook for help.',
 ];
 
 type ExternalProps = {|


### PR DESCRIPTION
### Description of the Change

-Adds to the `Migrations` array some logic for the LONG and RPX tokens so that they still exist in the Asset table of the NT database, and thus will still show up in NT. This is a sort of manual intervention into the scraper and the NT database. I also added and edited logic for when/how the scraper will execute the migration function logic on startup.
-Added a line to the BuyNEO page to contact us via Twitter/FB if a user has issues.
-Fixed how the `yarn develop` command reads/sets the `nodeRpcUrl`/`rpcURL` option.

### Test Plan

Ran a local NEO•ONE node, local PG database, and ran the scraper. RPX and LONG now show up appropriately in NT when run locally. This DB will be pushed to our cloud infra.

### Issues

#234
