### PR TITLE
fix(migration): change migrations to account for network

### DIFF
--- a/packages/neotracker-server-scrape/src/createScraper$.ts
+++ b/packages/neotracker-server-scrape/src/createScraper$.ts
@@ -232,10 +232,10 @@ export const createScraper$ = ({
     }),
     mergeScanLatest<Context, Context>(async (_acc, context: Context) => {
       // tslint:disable-next-line no-loop-statement
-      for (const [name, migration, shouldMigrate] of migrations) {
+      for (const [name, migration, shouldMigrate, migrationNetwork] of migrations) {
         const shouldExecute = await context.migrationHandler.shouldExecute(name);
         const shouldDoMigration = await shouldMigrate(context);
-        if (shouldExecute && shouldDoMigration) {
+        if (shouldExecute && shouldDoMigration && environment.network === migrationNetwork) {
           await migration(context, name);
           await context.migrationHandler.onComplete(name);
         }

--- a/packages/neotracker-server-scrape/src/migrations/index.ts
+++ b/packages/neotracker-server-scrape/src/migrations/index.ts
@@ -1,4 +1,4 @@
-import { ConfirmedInvocationTransaction } from '@neo-one/client-full';
+import { ConfirmedInvocationTransaction, NetworkType } from '@neo-one/client-full';
 import {
   Asset as AssetModel,
   Coin as CoinModel,
@@ -87,7 +87,7 @@ const rpxMigrationBlock = 1444840;
 const longMigrationBlock = 5752874;
 
 // tslint:disable-next-line export-name
-export const migrations: ReadonlyArray<readonly [string, MigrationFunc, ShouldMigrateFunc]> = [
+export const migrations: ReadonlyArray<readonly [string, MigrationFunc, ShouldMigrateFunc, NetworkType]> = [
   [
     'RPX',
     async (context, _) => {
@@ -108,6 +108,7 @@ export const migrations: ReadonlyArray<readonly [string, MigrationFunc, ShouldMi
       ]);
     },
     async (context) => migrationBlockAboveCurrentBlock({ context, migrationBlock: rpxMigrationBlock }),
+    'main',
   ],
   [
     'LONG',
@@ -129,5 +130,6 @@ export const migrations: ReadonlyArray<readonly [string, MigrationFunc, ShouldMi
       ]);
     },
     async (context) => migrationBlockAboveCurrentBlock({ context, migrationBlock: longMigrationBlock }),
+    'main',
   ],
 ];


### PR DESCRIPTION
### Description of the Change

Add migration network to migrations so that we don't inadvertently do migrations in TestNet that should only be done with MainNet, and vice-versa.

### Test Plan

No test needed. Going to deploy.
