### PR TITLE
feat(cache): increase moonpay hash cache

### DIFF
--- a/packages/neotracker-server-graphql/src/roots/MoonPayRootCall.ts
+++ b/packages/neotracker-server-graphql/src/roots/MoonPayRootCall.ts
@@ -17,7 +17,7 @@ interface MoonPayOptions {
 
 const serverGQLLogger = createChild(serverLogger, { component: 'graphql' });
 
-const hashCache = new LRUCache<string, string>(100);
+const hashCache = new LRUCache<string, string>(10000);
 
 export class MoonPayRootCall extends RootCall {
   public static readonly fieldName: string = 'moonpay';


### PR DESCRIPTION
### Description of the Change

Increases the size of the cache used for the MoonPay hashing function. The `LRUCache` is sized by number of items in the cache. Each item consists of a key and a value, both of which are strings. The key is the URL string, which is let's say about 100 characters. And the value is the SHA256 hash of the URL, which always comes out to a length of 44 characters. In JS each character should be 2 bytes. So each item will take up about 300 bytes (rounding up). So with the original size of 100 the cache would only take up about 30KB. Now, with a cache of 10,000 the cache should take up about 3MB. This will allow NT to handle more traffic as the hashing won't consume as much memory for each concurrent user session.

This is a temporary solution to this hash function crashing our web pods. The real solution is to figure out why that GQL query is being made so often, thus causing the web pods to perform far more work than is necessary.

### Test Plan

Deployed and lead to far less pod restarts.

### Issues

#225