### PR TITLE
fix(memory): increase nodejs max memory in docker image

### DIFF
--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -81,4 +81,4 @@ COPY --from=builder tmp/neotracker/dist/neotracker-core/ neotracker-core/
 COPY yarn.lock neotracker-core/
 WORKDIR /neotracker-core
 RUN yarn install --production
-ENTRYPOINT ["/usr/local/bin/node", "--max-old-space-size=1024","bin/neotracker", "neotracker"]
+ENTRYPOINT ["/usr/local/bin/node", "--max-old-space-size=2048", "bin/neotracker", "neotracker"]


### PR DESCRIPTION
### Description of the Change

See title. 1gb to 2gb max memory.

### Test Plan

Deployed to production. Looks good so far.

### Issues

#225