### PR TITLE
fix(memory): remove memory size from Dockerfile. put in k8s config

### DIFF
--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -81,4 +81,4 @@ COPY --from=builder tmp/neotracker/dist/neotracker-core/ neotracker-core/
 COPY yarn.lock neotracker-core/
 WORKDIR /neotracker-core
 RUN yarn install --production
-ENTRYPOINT ["/usr/local/bin/node", "--max-old-space-size=2048", "bin/neotracker", "neotracker"]
+ENTRYPOINT ["/usr/local/bin/node", "bin/neotracker", "neotracker"]


### PR DESCRIPTION
### Description of the Change

It appears that setting `--max-old-space-size` here doesn't seem to make it into the container's node process. But setting it as an environment variable in the k8s config does. And it's easier to edit the memory size there.

### Test Plan

Tested by deploying to production and looking at logs.

### Issues

#225